### PR TITLE
Add autokey unknown alphabet solving mode

### DIFF
--- a/vigSolver5.html
+++ b/vigSolver5.html
@@ -57,6 +57,7 @@
         <option value="vig_sub">Vigenère + unknown substitution (pre‑sub on plaintext)</option>
         <option value="vig_sub_post">Vigenère + unknown substitution (post‑sub on ciphertext)</option>
         <option value="vig_custom_alpha">Vigenère with unknown alphabet (shared custom order)</option>
+        <option value="autokey_custom_alpha">Autokey with unknown alphabet (shared custom order)</option>
       </select>
       <button id="render">Render grid</button>
       <button id="test">Test cribs</button>
@@ -784,8 +785,8 @@ for (let __ai = 0; __ai < letters.length; __ai++) {
     
     const cipherSeg = cLetters.slice(startPos, endPos + 1).join('');
     const plainSeg = word;
-    // Special fast path for unknown alphabet mode: propagation-only check across key lengths.
-    if (op === 'vig_custom_alpha'){
+    // Special fast path for unknown alphabet modes: propagation-only check across key lengths.
+    if (op === 'vig_custom_alpha' || op === 'autokey_custom_alpha'){
       const candidateCribMap = Object.assign({}, cribMap);
       for (let t = 0; t < word.length; t++) {
   const letterStep = startPos + t;
@@ -797,12 +798,15 @@ for (let __ai = 0; __ai < letters.length; __ai++) {
       let possible = false;
       for (let kk = minK; kk <= maxK; kk++){
         try{
-          const ok = solveVigUnknownAlphabet(letters, candidateCribMap, kk, {propagateOnly:true, quickTrials:getQuickTrials(), trialDepth:getTrialDepth()});
+          const solverOpts = {propagateOnly:true, quickTrials:getQuickTrials(), trialDepth:getTrialDepth()};
+          const ok = (op === 'vig_custom_alpha')
+            ? solveVigUnknownAlphabet(letters, candidateCribMap, kk, solverOpts)
+            : solveAutokeyUnknownAlphabet(letters, candidateCribMap, kk, solverOpts);
           if (ok){ possible = true; break; }
         }catch(e){ /* ignore solver errors for this quick check */ }
       }
       if (possible){
-        results.push({ word: word, keyLength: null, key: null, decrypted: null, fitness: null, possible: true, op: 'vig_custom_alpha' });
+        results.push({ word: word, keyLength: null, key: null, decrypted: null, fitness: null, possible: true, op: op });
       }
       continue; // move to next word
     }
@@ -928,9 +932,9 @@ for (let __ai = 0; __ai < letters.length; __ai++) {
   results.sort((a, b) => b.fitness - a.fitness);
   
   // If unknown alphabet mode and we only found a small set of possible words, expand them fully.
-  if (op === 'vig_custom_alpha') {
+  if (op === 'vig_custom_alpha' || op === 'autokey_custom_alpha') {
     const SMALL_THRESHOLD = 25;
-    const possible = results.filter(r => r.op === 'vig_custom_alpha' && r.possible === true);
+    const possible = results.filter(r => r.op === op && r.possible === true);
     if (possible.length > 0 && possible.length < SMALL_THRESHOLD) {
       const expanded = [];
       for (const cand of possible) {
@@ -945,9 +949,13 @@ for (let __ai = 0; __ai < letters.length; __ai++) {
 }
         for (let kk=minK; kk<=maxK; kk++){
           try{
-            const sol = solveVigUnknownAlphabet(letters, candidateCribMap, kk);
+            const sol = (op === 'vig_custom_alpha')
+              ? solveVigUnknownAlphabet(letters, candidateCribMap, kk)
+              : solveAutokeyUnknownAlphabet(letters, candidateCribMap, kk);
             if (sol && sol.pos && sol.k) {
-              const fullDec = decryptWithCustomAlphabet(letters, sol.pos, sol.k);
+              const fullDec = (op === 'vig_custom_alpha')
+                ? decryptWithCustomAlphabet(letters, sol.pos, sol.k)
+                : decryptAutokeyUnknownAlphabet(letters, sol.pos, sol.k);
               const decLetters = sanitize(fullDec).split('');
               const fitness = englishFitness(decLetters);
               // Build alphabet string from pos[]
@@ -961,7 +969,7 @@ for (let __ai = 0; __ai < letters.length; __ai++) {
                 alphabet: alphaStr,
                 decrypted: fullDec,
                 fitness: fitness,
-                op: 'vig_custom_alpha_full'
+                op: op + '_full'
               });
             }
           }catch(e){ /* ignore, continue */ }
@@ -970,7 +978,7 @@ for (let __ai = 0; __ai < letters.length; __ai++) {
       // Prefer expanded results if we got any; otherwise fall back to the quick possibles
       if (expanded.length) {
         // Merge with any non-unknown results we computed (e.g., other ops)
-        const nonUnknown = results.filter(r => r.op !== 'vig_custom_alpha');
+        const nonUnknown = results.filter(r => r.op !== op);
         const merged = nonUnknown.concat(expanded);
         merged.sort((a,b)=> (isFinite(b.fitness)?b.fitness:-1) - (isFinite(a.fitness)?a.fitness:-1));
         results.length = 0;
@@ -1364,6 +1372,256 @@ function solveVigUnknownAlphabet(letters, cribMap, m, options){
 }
 
 
+
+function solveAutokeyUnknownAlphabet(letters, cribMap, m, options){
+  const N = 26;
+  if (!Number.isFinite(m) || m <= 0) return null;
+  const segments = collectContiguousCribs(letters, cribMap);
+  if (!segments.length) return null;
+  const { absToLetterStep } = buildLetterStreams(letters);
+  const stepPlain = new Map();
+  const stepCipher = new Map();
+  for (const seg of segments){
+    const startStep = absToLetterStep[seg.start];
+    if (startStep == null || startStep < 0) continue;
+    for (let t=0; t<seg.cipherSeg.length; t++){
+      const step = startStep + t;
+      const pSym = A2I[seg.plainSeg[t]];
+      const cSym = A2I[seg.cipherSeg[t]];
+      if (stepPlain.has(step) && stepPlain.get(step) !== pSym) return null;
+      if (stepCipher.has(step) && stepCipher.get(step) !== cSym) return null;
+      stepPlain.set(step, pSym);
+      stepCipher.set(step, cSym);
+    }
+  }
+  if (!stepPlain.size) return null;
+
+  const constraints = [];
+  const letterDeg = new Array(N).fill(0);
+  const keyDeg = new Array(m).fill(0);
+  const steps = Array.from(stepPlain.keys()).sort((a,b)=>a-b);
+  for (const step of steps){
+    const pSym = stepPlain.get(step);
+    const cSym = stepCipher.get(step);
+    if (pSym == null || cSym == null) continue;
+    if (step < m){
+      constraints.push({ type:'init', idx:step, pSym, cSym });
+      keyDeg[step]++;
+    }
+    const depStep = step - m;
+    if (depStep >= 0 && stepPlain.has(depStep)){
+      const depSym = stepPlain.get(depStep);
+      constraints.push({ type:'feed', idx:step, pSym, cSym, depSym });
+      letterDeg[depSym]++;
+    }
+    letterDeg[pSym]++;
+    letterDeg[cSym]++;
+  }
+  if (!constraints.length) return null;
+
+  const pos = new Array(N).fill(null);
+  const used = new Array(N).fill(false);
+  const keyInit = new Array(m).fill(null);
+
+  let anchor = -1, best = -1;
+  for (let L=0; L<N; L++){
+    if (letterDeg[L] > best){
+      best = letterDeg[L];
+      anchor = L;
+    }
+  }
+  if (anchor !== -1){
+    pos[anchor] = 0;
+    used[0] = true;
+  }
+
+  const mod = (x)=>((x%N)+N)%N;
+
+  function assignLetter(idx, value){
+    if (idx == null) return {ok:true, changed:false};
+    value = mod(value);
+    if (pos[idx] === null){
+      if (used[value]) return {ok:false, changed:false};
+      pos[idx] = value;
+      used[value] = true;
+      return {ok:true, changed:true};
+    }
+    return {ok: pos[idx] === value, changed:false};
+  }
+
+  function assignKey(idx, value){
+    value = mod(value);
+    if (keyInit[idx] === null){
+      keyInit[idx] = value;
+      return {ok:true, changed:true};
+    }
+    return {ok: keyInit[idx] === value, changed:false};
+  }
+
+  function propagate(){
+    let changed = true;
+    while (changed){
+      changed = false;
+      for (const cons of constraints){
+        if (cons.type === 'init'){
+          const a = pos[cons.pSym];
+          const b = pos[cons.cSym];
+          const keyVal = keyInit[cons.idx];
+          if (a !== null && b !== null){
+            const res = assignKey(cons.idx, b - a);
+            if (!res.ok) return false;
+            if (res.changed) changed = true;
+          }
+          if (a !== null && keyVal !== null){
+            const res = assignLetter(cons.cSym, a + keyVal);
+            if (!res.ok) return false;
+            if (res.changed) changed = true;
+          }
+          if (b !== null && keyVal !== null){
+            const res = assignLetter(cons.pSym, b - keyVal);
+            if (!res.ok) return false;
+            if (res.changed) changed = true;
+          }
+        } else {
+          const a = pos[cons.pSym];
+          const b = pos[cons.cSym];
+          const dep = pos[cons.depSym];
+          if (a !== null && dep !== null){
+            const res = assignLetter(cons.cSym, a + dep);
+            if (!res.ok) return false;
+            if (res.changed) changed = true;
+          }
+          const bNow = pos[cons.cSym];
+          const aNow = pos[cons.pSym];
+          const depNow = pos[cons.depSym];
+          if (bNow !== null && aNow !== null){
+            const res = assignLetter(cons.depSym, bNow - aNow);
+            if (!res.ok) return false;
+            if (res.changed) changed = true;
+          }
+          if (bNow !== null && depNow !== null){
+            const res = assignLetter(cons.pSym, bNow - depNow);
+            if (!res.ok) return false;
+            if (res.changed) changed = true;
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  function chooseVar(){
+    let bestLetter=-1, bestScore=-1;
+    for (let L=0; L<N; L++){
+      if (pos[L]===null && letterDeg[L]>bestScore){
+        bestScore = letterDeg[L];
+        bestLetter = L;
+      }
+    }
+    if (bestLetter !== -1 && bestScore>0) return {type:'letter', idx:bestLetter};
+    let bestKey=-1, bestKeyScore=-1;
+    for (let i=0;i<m;i++){
+      if (keyInit[i]===null && keyDeg[i]>bestKeyScore){
+        bestKeyScore = keyDeg[i];
+        bestKey = i;
+      }
+    }
+    if (bestLetter !== -1) return {type:'letter', idx:bestLetter};
+    if (bestKey !== -1) return {type:'key', idx:bestKey};
+    return null;
+  }
+
+  function snapshot(){
+    return { pos: pos.slice(), used: used.slice(), key: keyInit.slice() };
+  }
+  function restore(state){
+    for (let i=0;i<N;i++){ pos[i]=state.pos[i]; used[i]=state.used[i]; }
+    for (let i=0;i<m;i++){ keyInit[i]=state.key[i]; }
+  }
+
+  function dfs(){
+    if (!propagate()) return null;
+    const sel = chooseVar();
+    if (!sel){
+      const posFull = pos.slice();
+      const free = [];
+      for (let v=0; v<N; v++){ if (!used[v]) free.push(v); }
+      for (let L=0; L<N; L++){ if (posFull[L]===null) posFull[L] = free.shift(); }
+      const keyFull = keyInit.slice().map(x => x===null ? 0 : mod(x));
+      return { pos: posFull, k: keyFull };
+    }
+    if (sel.type === 'letter'){
+      const candSet = new Set();
+      for (const cons of constraints){
+        if (cons.pSym === sel.idx){
+          if (cons.type === 'init'){
+            const b = pos[cons.cSym];
+            const keyVal = keyInit[cons.idx];
+            if (b !== null && keyVal !== null) candSet.add(mod(b - keyVal));
+          } else {
+            const b = pos[cons.cSym];
+            const dep = pos[cons.depSym];
+            if (b !== null && dep !== null) candSet.add(mod(b - dep));
+          }
+        }
+        if (cons.cSym === sel.idx){
+          if (cons.type === 'init'){
+            const a = pos[cons.pSym];
+            const keyVal = keyInit[cons.idx];
+            if (a !== null && keyVal !== null) candSet.add(mod(a + keyVal));
+          } else {
+            const a = pos[cons.pSym];
+            const dep = pos[cons.depSym];
+            if (a !== null && dep !== null) candSet.add(mod(a + dep));
+          }
+        }
+        if (cons.type === 'feed' && cons.depSym === sel.idx){
+          const a = pos[cons.pSym];
+          const b = pos[cons.cSym];
+          if (b !== null && a !== null) candSet.add(mod(b - a));
+        }
+      }
+      const free = [];
+      for (let v=0; v<N; v++){ if (!used[v]) free.push(v); }
+      const candidates = candSet.size ? Array.from(candSet).filter(v => !used[v]) : free;
+      for (const val of candidates){
+        const snap = snapshot();
+        const vv = mod(val);
+        pos[sel.idx] = vv;
+        used[vv] = true;
+        const res = dfs();
+        if (res) return res;
+        restore(snap);
+      }
+    } else {
+      const candSet = new Set();
+      for (const cons of constraints){
+        if (cons.type === 'init' && cons.idx === sel.idx){
+          const a = pos[cons.pSym];
+          const b = pos[cons.cSym];
+          if (a !== null && b !== null) candSet.add(mod(b - a));
+        }
+      }
+      const candidates = candSet.size ? Array.from(candSet) : [...Array(N).keys()];
+      for (const val of candidates){
+        const snap = snapshot();
+        keyInit[sel.idx] = mod(val);
+        const res = dfs();
+        if (res) return res;
+        restore(snap);
+      }
+    }
+    return null;
+  }
+
+  if (options && options.propagateOnly){
+    return propagate();
+  }
+
+  return dfs();
+}
+
+
 function decryptWithCustomAlphabet(letters, pos, k){
   const N=26;
   const inv=new Array(N); for (let L=0;L<N;L++) inv[pos[L]] = A[L];
@@ -1379,10 +1637,36 @@ function decryptWithCustomAlphabet(letters, pos, k){
   return out;
 }
 
+function decryptAutokeyUnknownAlphabet(letters, pos, keyInit){
+  const N = 26;
+  const inv = new Array(N); for (let L=0; L<N; L++) inv[pos[L]] = A[L];
+  const plainPositions = [];
+  let step = 0;
+  let out = '';
+  for (let i=0; i<letters.length; i++){
+    const ch = letters[i];
+    if (!isLetter(ch)){ out += ch; continue; }
+    const cIdx = pos[A2I[ch.toUpperCase()]];
+    let keyVal;
+    if (step < keyInit.length){
+      keyVal = keyInit[step];
+    } else {
+      keyVal = plainPositions[step - keyInit.length];
+    }
+    if (keyVal == null) keyVal = 0;
+    keyVal = ((keyVal % N) + N) % N;
+    const pIdx = ((cIdx - keyVal) % N + N) % N;
+    plainPositions.push(pIdx);
+    out += inv[pIdx];
+    step++;
+  }
+  return out;
+}
+
 // ===== Non-destructive wrapper for Test button =====
-async function testCribsWrapper(){
+async function runUnknownAlphabetInline(){
   const op = document.getElementById('op').value;
-  if (op !== 'vig_custom_alpha'){ 
+  if (op !== 'vig_custom_alpha' && op !== 'autokey_custom_alpha'){
     hideProgress();
     return testCribs(); // call the original
   }
@@ -1419,12 +1703,17 @@ async function testCribsWrapper(){
   out.textContent='';
   if (segments.length === 0){ summary.textContent='Enter at least one crib segment.'; return; }
   const total = (maxK - minK + 1);
-  showProgress(total, 'Unknown alphabet Vigenère');
+  const isVigMode = (op === 'vig_custom_alpha');
+  showProgress(total, isVigMode ? 'Unknown alphabet Vigenère' : 'Autokey + unknown alphabet');
   const results=[];
   for (let kLen=minK; kLen<=maxK; kLen++){
-    const sol = solveVigUnknownAlphabet(letters, cribMap, kLen);
+    const sol = isVigMode
+      ? solveVigUnknownAlphabet(letters, cribMap, kLen)
+      : solveAutokeyUnknownAlphabet(letters, cribMap, kLen);
     if (sol){
-      const dec = decryptWithCustomAlphabet(letters, sol.pos, sol.k);
+      const dec = isVigMode
+        ? decryptWithCustomAlphabet(letters, sol.pos, sol.k)
+        : decryptAutokeyUnknownAlphabet(letters, sol.pos, sol.k);
       const fitness = englishFitness( sanitize(dec).split('') );
       results.push({ keyLength:kLen, key: sol.k.map(x=>A[x]).join(''), preview: dec.slice(0,160), score: fitness, posRaw: sol.pos, kRaw: sol.k });
     }
@@ -1432,44 +1721,47 @@ async function testCribsWrapper(){
     if ((kLen - minK) % 1 === 0) await uiYield();
   }
   hideProgress();
-  
+
   if (!results.length){
-    // Build a quick debug: report constraints coverage and contradictions per m
-    let debugLines = [];
-    for (let kLen=minK; kLen<=maxK; kLen++){
-      // Rebuild constraints similar to solver head
-      const { cLetters, absToLetterStep } = buildLetterStreams(letters);
-      const stepToAbs = [];
-      for (let ai=0; ai<letters.length; ai++){ const s = absToLetterStep[ai]; if (s>=0) stepToAbs[s]=ai; }
-      const cons=[];
-      for (let i=0;i<letters.length;i++){
-        if (!isLetter(letters[i])) continue;
-        const baseStep = absToLetterStep[i];
-        const cribRaw = cribMap[i];
-        if (!cribRaw) continue;
-        const cribLetters = sanitize(cribRaw);
-        for (let j=0; j<cribLetters.length; j++){
-          const p = cribLetters[j];
-          if (!/[A-Z]/.test(p)) continue;
-          const step = baseStep + j;
-          const absIdx = stepToAbs[step];
-          if (absIdx === undefined) break;
-          const c = letters[absIdx].toUpperCase();
-          if (!/[A-Z]/.test(c)) continue;
-          cons.push({ r: step % kLen, pSym: A2I[p], cSym: A2I[c] });
+    if (isVigMode){
+      // Build a quick debug: report constraints coverage and contradictions per m
+      let debugLines = [];
+      for (let kLen=minK; kLen<=maxK; kLen++){
+        const { cLetters, absToLetterStep } = buildLetterStreams(letters);
+        const stepToAbs = [];
+        for (let ai=0; ai<letters.length; ai++){ const s = absToLetterStep[ai]; if (s>=0) stepToAbs[s]=ai; }
+        const cons=[];
+        for (let i=0;i<letters.length;i++){
+          if (!isLetter(letters[i])) continue;
+          const baseStep = absToLetterStep[i];
+          const cribRaw = cribMap[i];
+          if (!cribRaw) continue;
+          const cribLetters = sanitize(cribRaw);
+          for (let j=0; j<cribLetters.length; j++){
+            const p = cribLetters[j];
+            if (!/[A-Z]/.test(p)) continue;
+            const step = baseStep + j;
+            const absIdx = stepToAbs[step];
+            if (absIdx === undefined) break;
+            const c = letters[absIdx].toUpperCase();
+            if (!/[A-Z]/.test(c)) continue;
+            cons.push({ r: step % kLen, pSym: A2I[p], cSym: A2I[c] });
+          }
         }
+        const byR = Array.from({length:kLen},()=>[]); cons.forEach(c=>byR[c.r].push(c));
+        let cover = byR.filter(g=>g.length>0).length;
+        const contrad = false;
+        debugLines.push(`m=${kLen}: constraints=${cons.length}, residuesHit=${cover}/${kLen}, contradictions=${contrad}`);
       }
-      // residue coverage and contradictions
-      const byR = Array.from({length:kLen},()=>[]); cons.forEach(c=>byR[c.r].push(c));
-      let cover = byR.filter(g=>g.length>0).length;
-      // Skip contradiction pre-check here: alphabet positions are unknown in this phase.
-      // We only compute contradictions inside the DFS when pos[] becomes available.
-      const contrad = false;
-      debugLines.push(`m=${kLen}: constraints=${cons.length}, residuesHit=${cover}/${kLen}, contradictions=${contrad}`);
+      summary.textContent = `No solution for key lengths ${minK}..${maxK} under this model.`;
+      const pre = document.createElement('pre'); pre.className='small muted'; pre.textContent = debugLines.join('\n');
+      out.appendChild(pre);
+    } else {
+      summary.textContent = `No solution for key lengths ${minK}..${maxK} under autokey + unknown alphabet.`;
+      const pre = document.createElement('pre'); pre.className='small muted';
+      pre.textContent = 'Autokey mode relies on chained crib coverage (positions spaced by the key length). Try adding overlapping cribs or narrowing the key-length range.';
+      out.appendChild(pre);
     }
-    summary.textContent = `No solution for key lengths ${minK}..${maxK} under this model.`;
-    const pre = document.createElement('pre'); pre.className='small muted'; pre.textContent = debugLines.join('\n');
-    out.appendChild(pre);
     return;
   }
   results.sort((a,b)=>b.score - a.score);
@@ -1483,11 +1775,13 @@ try{
       const inv = new Array(N);
       for (let L=0; L<N; L++){ inv[best.posRaw[L]] = A[L]; }
       const alphaStr = inv.join('');
-      const fullText = decryptWithCustomAlphabet(letters, best.posRaw, best.kRaw);
+      const fullText = isVigMode
+        ? decryptWithCustomAlphabet(letters, best.posRaw, best.kRaw)
+        : decryptAutokeyUnknownAlphabet(letters, best.posRaw, best.kRaw);
       const fullBlock = document.createElement('pre');
       fullBlock.textContent =
         `Best candidate (m=${best.keyLength})\n` +
-        `key residues: ${best.key}\n` +
+        `initial key: ${best.key}\n` +
         `alphabet:    ${alphaStr}\n\n` +
         fullText;
       out.appendChild(fullBlock);
@@ -1495,16 +1789,16 @@ try{
   }
 }catch(e){ console.warn('Summary render failed', e); }
 
-  summary.textContent = `Found ${results.length} solution(s) for unknown alphabet Vigenère.`;
+  summary.textContent = isVigMode
+    ? `Found ${results.length} solution(s) for unknown alphabet Vigenère.`
+    : `Found ${results.length} solution(s) for autokey + unknown alphabet.`;
   results.slice(0,50).forEach((r,idx)=>{
     const div=document.createElement('div'); div.className='row';
-    const head=document.createElement('div'); head.textContent = `#${idx+1}  m=${r.keyLength}  keyResidues=${r.key}`;
+    const head=document.createElement('div'); head.textContent = `#${idx+1}  m=${r.keyLength}  initialKey=${r.key}`;
     const body=document.createElement('div'); body.className='small muted'; body.textContent=r.preview;
     div.appendChild(head); div.appendChild(body); out.appendChild(div);
   });
 }
-document.getElementById('test').removeEventListener('click', testCribs);
-document.getElementById('test').addEventListener('click', testCribsWrapper);
 </script>
 
   </div>
@@ -1847,7 +2141,7 @@ document.getElementById('test').addEventListener('click', testCribsWrapper);
         })();
 
         // Compute actual keyword letters using inv alphabet
-        const keyResidues = best.key;
+        const initialKey = best.key;
         let keyLetters = "";
         for (let i=0; i<best.k.length; i++){
           const shift = best.k[i];
@@ -1858,8 +2152,8 @@ document.getElementById('test').addEventListener('click', testCribsWrapper);
         }
         let txt = "";
         txt += "Best candidate (m=" + best.keyLength + ")\n";
-        txt += "key residues: " + best.key + "\n";
-        txt += "key (letters): " + keyLetters + "\n";
+        txt += "initial key (residues): " + best.key + "\n";
+        txt += "initial key (letters): " + keyLetters + "\n";
         txt += "alphabet:    " + inv + "\n\n";
         txt += best.full + "\n\n";
         results.slice(1, Math.min(10, results.length)).forEach((r, i) => {
@@ -1918,6 +2212,9 @@ function getCribMapFromDOM(){
 
 async function testCribsWrapper(){
   const op = document.getElementById('op').value;
+  if (op === 'autokey_custom_alpha'){
+    return runUnknownAlphabetInline();
+  }
   if (op !== 'vig_custom_alpha'){
     hideProgress();
     return testCribs();
@@ -2025,7 +2322,7 @@ UA_WORKER.onmessage = (ev) => {
       }
       results.slice(0,50).forEach((r,idx)=>{
         const div=document.createElement('div'); div.className='row';
-        const head=document.createElement('div'); head.textContent = `#${idx+1}  m=${r.keyLength}  keyResidues=${r.key}`;
+        const head=document.createElement('div'); head.textContent = `#${idx+1}  m=${r.keyLength}  initialKey=${r.key}`;
         const body=document.createElement('div'); body.className='small muted'; body.textContent=r.preview||'';
         div.appendChild(head); div.appendChild(body); out.appendChild(div);
       });


### PR DESCRIPTION
## Summary
- add an Autokey + unknown alphabet mode to the operation selector and reuse the grid UI
- implement a propagation/backtracking solver and decryptor for the autokey unknown alphabet case
- update inline solving, wordlist brute force checks, and summary rendering to handle both Vigenère and Autokey unknown alphabet modes

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e47b8caa308331b9d58484f80cd1c2