### PR TITLE
Improve crib input usability on mobile

### DIFF
--- a/vigSolver5.html
+++ b/vigSolver5.html
@@ -14,11 +14,11 @@
     .panel { background:var(--panel); border:1px solid rgba(255,255,255,0.06); padding:12px; border-radius:8px; margin-bottom:12px }
     textarea { width:100%; height:90px; font-family: monospace; font-size:14px; padding:8px; border-radius:6px; background:#071022; color:#dbeafe; border:1px solid rgba(255,255,255,0.08) }
     .grid { display:flex; gap:6px; flex-wrap:wrap; margin-top:10px }
-    .cell { width:34px; text-align:center; position:relative }
+    .cell { width:34px; text-align:center; position:relative; display:flex; flex-direction:column; align-items:center; gap:4px }
     .cell.selecting { cursor:pointer }
     .cell.selected .char { background:#1e3a5f; border:2px solid var(--accent); }
-    .char { display:block; padding:6px 4px; background:#081426; border-radius:6px; font-weight:700; border:2px solid transparent; }
-    input.cribin { width:100%; text-align:center; border-radius:6px; padding:6px 4px; background:var(--input-bg); color:var(--input-ink); border:1px solid var(--input-bd); font-weight:700 }
+    .char { display:block; padding:6px 4px; background:#081426; border-radius:6px; font-weight:700; border:2px solid transparent; width:100%; box-sizing:border-box }
+    input.cribin { width:100%; text-align:center; border-radius:6px; padding:8px 4px; background:var(--input-bg); color:var(--input-ink); border:1px solid var(--input-bd); font-weight:700; box-sizing:border-box; font-size:18px; min-height:36px }
     input.cribin:focus { outline:2px solid var(--accent); outline-offset:0 }
     input.cribin[disabled]{ opacity:.35; cursor:not-allowed }
     .controls { display:flex; gap:8px; align-items:center; margin-top:10px; flex-wrap:wrap }
@@ -39,6 +39,12 @@
     .score { color:var(--accent); font-weight:700 }
     .selection-info { background:#081426; padding:8px; border-radius:6px; margin-top:8px; display:none }
     .selection-info.active { display:block }
+    @media (max-width: 640px) {
+      .grid { gap:4px }
+      .cell { width:42px }
+      .char { font-size:16px; padding:6px 3px }
+      input.cribin { min-height:40px; font-size:20px; padding:10px 4px }
+    }
   </style>
 </head>
 <body>
@@ -263,19 +269,22 @@ function renderGrid(){
       
       // Selection mode click handler
       cell.addEventListener('click', (e) => {
-        if (!selectionMode) return;
-        e.stopPropagation();
-        
-        const clickedIdx = parseInt(cell.dataset.letterIdx);
-        
-        if (selectionStart === -1){
-          selectionStart = clickedIdx;
-          selectionEnd = clickedIdx;
-        } else {
-          selectionEnd = clickedIdx;
+        if (selectionMode){
+          e.stopPropagation();
+
+          const clickedIdx = parseInt(cell.dataset.letterIdx);
+
+          if (selectionStart === -1){
+            selectionStart = clickedIdx;
+            selectionEnd = clickedIdx;
+          } else {
+            selectionEnd = clickedIdx;
+          }
+
+          updateSelection();
+        } else if (!crib.disabled) {
+          crib.focus();
         }
-        
-        updateSelection();
       });
       
       crib.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- update crib grid layout to use a flex column design so inputs stay visible on narrow screens
- increase crib input sizing, add responsive tweaks, and ensure consistent box sizing for mobile usability
- focus crib inputs when tapping the cell outside of selection mode to simplify touch interaction

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4dea91ae883318949804bdf920250