### PR TITLE
Fix autokey brute-force progress counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -2484,7 +2484,12 @@ try{
                     }
                   } catch(e){}
                 }
-                if (!plausible.length) continue;
+                if (!plausible.length){
+                  if (shouldReport(idx)){
+                    postMessage({ kind:'brute_progress', done: idx+1, total: progressTotal, checked:wordsChecked, skipped:wordsSkipped });
+                  }
+                  continue;
+                }
                 for (const kk of plausible){
                   if (__cancelled) break;
                   try {


### PR DESCRIPTION
## Summary
- ensure the brute-force worker reports progress even when no plausible autokey candidates are found
- keep the progress panel's checked-word count in sync with the final summary

## Testing
- manual verification via Playwright script to confirm the progress label updates while brute forcing

------
https://chatgpt.com/codex/tasks/task_e_68e5b605e90883319e7eb3bcdfab8b5a