### PR TITLE
Implement autokey brute-force optimizations

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,15 @@
-placeholder
+# Cipher Crib Tester
+
+This project hosts a single-page tool for experimenting with Vigenère-family ciphers. Paste a ciphertext, pin plaintext cribs under specific columns, and either test your assignments directly or run a wordlist-driven brute force to explore candidate words.
+
+## Autokey + unknown alphabet brute-forcer performance
+
+The autokey + unknown alphabet mode relies on a constraint solver that tries to deduce both the mixed alphabet and the autokey seed from the crib placements. When the brute-forcer evaluates each candidate word, it first runs a cheap "quick trial" phase that only performs propagation and a handful of shallow randomized guesses (`quickTrials` × `trialDepth`). That phase rejects obviously inconsistent words quickly, so iterations with low coverage or conflicting cribs finish almost immediately.
+
+If a word survives the quick trial, the solver has to perform a full depth-first search over the remaining unknown letters and key positions while maintaining the bijective alphabet mapping. The amount of work this backtracking search needs varies wildly: dense crib coverage forces many deterministic deductions, but sparse coverage leaves large parts of the alphabet unassigned and therefore expands the search tree. Those cases can keep the worker busy for noticeably longer before it either finds a consistent solution or exhausts all possibilities.
+
+In short, the variability you see reflects how constrained the puzzle becomes after a particular candidate is inserted—tight constraints yield fast rejections or solutions, while loose constraints require the solver to explore far more combinations.
+
+## Optimizing the autokey brute-forcer
+
+See [`docs/autokey_optimizations.md`](docs/autokey_optimizations.md) for a deeper breakdown of why the solver occasionally performs a full search and several concrete optimization strategies that can reduce those worst-case stalls.

--- a/docs/autokey_optimizations.md
+++ b/docs/autokey_optimizations.md
@@ -1,0 +1,36 @@
+# Autokey Unknown-Alphabet Brute-Forcer Optimizations
+
+This note explains why the current worker occasionally falls back to an expensive search and outlines concrete optimizations we can pursue.
+
+## Why the solver sometimes performs a full search
+
+When we test a candidate crib in the `autokey_custom_alpha` mode we have to recover **both**:
+
+1. the permutation that maps plaintext letters to ciphertext letters, and
+2. the initial autokey seed of length *m*.
+
+The helper `solveAutokeyUnknownAlphabet` starts by consuming the fixed crib assignments and building a mixed list of constraints that relate plaintext symbols, ciphertext symbols, and the key residues (`r = step mod m`).【F:index.html†L1047-L1084】 After deterministic propagation has finished, the solver uses a full depth-first search (`dfs`) to assign the remaining residues and plaintext symbols while preserving the bijective alphabet mapping.【F:index.html†L1118-L1247】 If propagation cannot fix all variables (because the crib coverage is sparse or leaves mutually unconstrained components), the DFS must explore alternative assignments until it finds one that satisfies every constraint. That backtracking work is what causes the long “stuck” periods.
+
+## Existing pruning steps
+
+Before the DFS runs, the worker performs two lighter-weight filters:
+
+- During the quick trial phase we run the same solver with `propagateOnly` enabled, which performs deterministic propagation followed by a small number of randomized micro-searches (bounded by `quickTrials` and `trialDepth`).【F:index.html†L1007-L1096】 Words that fail this phase are rejected cheaply.
+- When the quick trial succeeds we perform the full solve once per plausible key length and, if successful, decrypt and score the result.【F:index.html†L2463-L2505】
+
+The quick trial catches many impossible words, but when it returns “maybe” we still need the exhaustive search to guarantee correctness.
+
+## Optimization directions
+
+Several improvements can reduce how often we reach the expensive DFS or how much work it has to do:
+
+1. **Stronger deterministic propagation.** We currently derive residue candidates from pairwise differences inside the quick trial, but the full solver only enforces arc consistency through repeated scans. Implementing a constraint queue (e.g. AC-3 style) or tracking dependency graph components would push more consequences without branching, shrinking the search space before DFS begins.【F:index.html†L1001-L1045】【F:index.html†L1085-L1096】
+2. **Reusable base state per selection.** For every candidate word we rebuild `collectContiguousCribs`, recompute `stepPlain`, and recreate the constraint arrays from scratch.【F:index.html†L2467-L2486】 We can cache the “static” constraints implied by the fixed cribs once, then clone and extend them with the word-specific assignments, avoiding repeated map/set construction.
+3. **Residue ordering informed by coverage.** The DFS already picks the residue with the highest constraint count, but we can feed it better heuristics, e.g. preferring residues that participate in the longest contiguous runs or have feed dependencies (`depSym`). That tends to lock the key faster and reduces branching.【F:index.html†L1098-L1116】【F:index.html†L1169-L1211】
+4. **Incremental alphabet pruning.** Because the permutation is bijective, as soon as a ciphertext symbol is assigned we can eliminate that value from all other plaintext symbols. Maintaining explicit candidate sets per letter (instead of recomputing `used`) enables forward checking so the DFS can abort earlier when a branch exhausts a symbol’s domain.
+5. **Search restarts guided by diagnostics.** The helper `autokeyCoverageDiagnostics` already reports residue coverage and missing feed links.【F:index.html†L1315-L1348】 We can expose this data in the UI and use it to auto-adjust `quickTrials` or refuse to start the worker if the coverage is so sparse that DFS would explode, prompting the user to place additional cribs.
+6. **Memoizing failed partial assignments.** When DFS backtracks it often revisits identical `(pos, k)` patterns produced in different orders. Hashing the assignments for connected components and caching the fact that they lead to contradictions would prune symmetric branches.
+
+## Takeaways
+
+The brute-forcer is correct but occasionally slow because the underlying constraint problem genuinely requires search when crib coverage is thin. By pushing more work into deterministic propagation, caching shared structures, and guiding the DFS with richer heuristics we can significantly reduce those worst-case stalls without changing the solver’s guarantees.

--- a/index.html
+++ b/index.html
@@ -420,6 +420,124 @@ function buildLetterStreams(letters){
   return { cLetters, absToLetterStep };
 }
 
+function buildAutokeyStepAssignments(letters, cribMap){
+  const { absToLetterStep } = buildLetterStreams(letters);
+  const segments = collectContiguousCribs(letters, cribMap);
+  const stepPlain = new Map();
+  const stepCipher = new Map();
+  let conflict = false;
+  for (const seg of segments){
+    const startStep = absToLetterStep[seg.start];
+    if (startStep == null || startStep < 0) continue;
+    for (let t=0; t<seg.cipherSeg.length; t++){
+      const step = startStep + t;
+      const pSym = A2I[seg.plainSeg[t]];
+      const cSym = A2I[seg.cipherSeg[t]];
+      if (stepPlain.has(step) && stepPlain.get(step) !== pSym){ conflict = true; break; }
+      if (stepCipher.has(step) && stepCipher.get(step) !== cSym){ conflict = true; break; }
+      stepPlain.set(step, pSym);
+      stepCipher.set(step, cSym);
+    }
+    if (conflict) break;
+  }
+  return { stepPlain, stepCipher, conflict };
+}
+
+function prepareAutokeyBaseState(assignments, m){
+  const N = 26;
+  if (!assignments || assignments.conflict) return null;
+  if (!Number.isFinite(m) || m <= 0) return null;
+  const stepPlain = assignments.stepPlain;
+  const stepCipher = assignments.stepCipher;
+  if (!stepPlain || !stepPlain.size) return null;
+  const constraints = [];
+  const letterDeg = new Array(N).fill(0);
+  const letterFeedDeg = new Array(N).fill(0);
+  const keyDeg = new Array(m).fill(0);
+  const steps = Array.from(stepPlain.keys()).sort((a,b)=>a-b);
+  for (const step of steps){
+    const pSym = stepPlain.get(step);
+    const cSym = stepCipher.get(step);
+    if (pSym == null || cSym == null) continue;
+    if (step < m){
+      constraints.push({ type:'init', idx:step, pSym, cSym });
+      keyDeg[step]++;
+    }
+    const depStep = step - m;
+    if (depStep >= 0 && stepPlain.has(depStep)){
+      const depSym = stepPlain.get(depStep);
+      constraints.push({ type:'feed', idx:step, pSym, cSym, depSym });
+      letterFeedDeg[depSym]++;
+    }
+    letterDeg[pSym]++;
+    letterDeg[cSym]++;
+  }
+  if (!constraints.length) return null;
+  const letterToConstraints = Array.from({length:N}, ()=>[]);
+  const keyToConstraints = Array.from({length:m}, ()=>[]);
+  constraints.forEach((cons, idx)=>{
+    letterToConstraints[cons.pSym].push(idx);
+    letterToConstraints[cons.cSym].push(idx);
+    if (cons.type === 'feed') letterToConstraints[cons.depSym].push(idx);
+    if (cons.type === 'init') keyToConstraints[cons.idx].push(idx);
+  });
+  const base = {
+    m,
+    constraints,
+    letterDeg,
+    letterFeedDeg,
+    keyDeg,
+    letterToConstraints,
+    keyToConstraints,
+    stepPlain,
+    stepCipher
+  };
+  base.posTemplate = new Array(N).fill(null);
+  base.usedTemplate = new Array(N).fill(false);
+  base.cipherOwnerTemplate = new Array(N).fill(-1);
+  base.keyTemplate = new Array(m).fill(null);
+  base.letterDomainsTemplate = Array.from({length:N}, ()=>Array(N).fill(1));
+  base.letterDomainSizesTemplate = new Array(N).fill(N);
+  base.keyDomainsTemplate = Array.from({length:m}, ()=>Array(N).fill(1));
+  base.keyDomainSizesTemplate = new Array(m).fill(N);
+  let anchor = -1;
+  let bestScore = -1;
+  for (let L=0; L<N; L++){
+    const deg = letterDeg[L];
+    if (!deg) continue;
+    const score = deg * 8 + (letterFeedDeg[L] || 0);
+    if (score > bestScore){
+      bestScore = score;
+      anchor = L;
+    }
+  }
+  if (anchor !== -1){
+    base.anchor = anchor;
+    base.anchorValue = 0;
+    base.posTemplate[anchor] = 0;
+    base.usedTemplate[0] = true;
+    base.cipherOwnerTemplate[0] = anchor;
+    const dom = base.letterDomainsTemplate[anchor];
+    for (let i=0; i<N; i++) dom[i] = (i === 0) ? 1 : 0;
+    base.letterDomainSizesTemplate[anchor] = 1;
+  }
+  return base;
+}
+
+function instantiateAutokeyState(base){
+  return {
+    pos: base.posTemplate.slice(),
+    used: base.usedTemplate.slice(),
+    cipherOwner: base.cipherOwnerTemplate.slice(),
+    keyInit: base.keyTemplate.slice(),
+    letterDomains: base.letterDomainsTemplate.map(arr => arr.slice()),
+    letterDomainSizes: base.letterDomainSizesTemplate.slice(),
+    keyDomains: base.keyDomainsTemplate.map(arr => arr.slice()),
+    keyDomainSizes: base.keyDomainSizesTemplate.slice()
+  };
+}
+
+
 // ===== Vigenère =====
 function solveCribVigenere(cipherSeg, plainSeg, keylen, letterStartPos){
   const tpl = Array(keylen).fill(null);
@@ -1260,252 +1378,513 @@ function solveVigUnknownAlphabet(letters, cribMap, m, options){
 function solveAutokeyUnknownAlphabet(letters, cribMap, m, options){
   const N = 26;
   if (!Number.isFinite(m) || m <= 0) return null;
-  const segments = collectContiguousCribs(letters, cribMap);
-  if (!segments.length) return null;
-  const { absToLetterStep } = buildLetterStreams(letters);
-  const stepPlain = new Map();
-  const stepCipher = new Map();
-  for (const seg of segments){
-    const startStep = absToLetterStep[seg.start];
-    if (startStep == null || startStep < 0) continue;
-    for (let t=0; t<seg.cipherSeg.length; t++){
-      const step = startStep + t;
-      const pSym = A2I[seg.plainSeg[t]];
-      const cSym = A2I[seg.cipherSeg[t]];
-      if (stepPlain.has(step) && stepPlain.get(step) !== pSym) return null;
-      if (stepCipher.has(step) && stepCipher.get(step) !== cSym) return null;
-      stepPlain.set(step, pSym);
-      stepCipher.set(step, cSym);
-    }
+  options = options || {};
+  let base = options.baseState;
+  if (!base){
+    const assignments = buildAutokeyStepAssignments(letters, cribMap);
+    if (!assignments || assignments.conflict) return null;
+    if (!assignments.stepPlain || !assignments.stepPlain.size) return null;
+    base = prepareAutokeyBaseState(assignments, m);
+    if (!base) return null;
+  } else if (base.m !== m){
+    return null;
   }
-  if (!stepPlain.size) return null;
+  const propagateOnly = !!options.propagateOnly;
+  const MAX_TRIALS = Number.isFinite(options.quickTrials) ? Math.max(0, options.quickTrials|0) : 30;
+  const TRIAL_DEPTH = Number.isFinite(options.trialDepth) ? Math.max(0, options.trialDepth|0) : 3;
+  const progressCb = options.progressCb;
 
-  const constraints = [];
-  const letterDeg = new Array(N).fill(0);
-  const keyDeg = new Array(m).fill(0);
-  const steps = Array.from(stepPlain.keys()).sort((a,b)=>a-b);
-  for (const step of steps){
-    const pSym = stepPlain.get(step);
-    const cSym = stepCipher.get(step);
-    if (pSym == null || cSym == null) continue;
-    if (step < m){
-      constraints.push({ type:'init', idx:step, pSym, cSym });
-      keyDeg[step]++;
-    }
-    const depStep = step - m;
-    if (depStep >= 0 && stepPlain.has(depStep)){
-      const depSym = stepPlain.get(depStep);
-      constraints.push({ type:'feed', idx:step, pSym, cSym, depSym });
-      letterDeg[depSym]++;
-    }
-    letterDeg[pSym]++;
-    letterDeg[cSym]++;
-  }
-  if (!constraints.length) return null;
+  const state = instantiateAutokeyState(base);
+  const pos = state.pos;
+  const used = state.used;
+  const cipherOwner = state.cipherOwner;
+  const keyInit = state.keyInit;
+  const letterDomains = state.letterDomains;
+  const letterDomainSizes = state.letterDomainSizes;
+  const keyDomains = state.keyDomains;
+  const keyDomainSizes = state.keyDomainSizes;
 
-  const pos = new Array(N).fill(null);
-  const used = new Array(N).fill(false);
-  const keyInit = new Array(m).fill(null);
+  const constraints = base.constraints;
+  if (!constraints || !constraints.length) return null;
+  const letterToConstraints = base.letterToConstraints;
+  const keyToConstraints = base.keyToConstraints;
+  const letterDeg = base.letterDeg;
+  const letterFeedDeg = base.letterFeedDeg || new Array(N).fill(0);
+  const keyDeg = base.keyDeg;
+  const anchor = base.anchor;
+  const anchorValue = base.anchorValue || 0;
+  const mLen = base.m;
 
   const mod = (x)=>((x%N)+N)%N;
 
-  function assignLetter(idx, value){
-    if (idx == null) return {ok:true, changed:false};
-    value = mod(value);
-    if (pos[idx] === null){
-      if (used[value]) return {ok:false, changed:false};
-      pos[idx] = value;
-      used[value] = true;
-      return {ok:true, changed:true};
-    }
-    return {ok: pos[idx] === value, changed:false};
+  function letterDomainValues(idx){
+    const arr = [];
+    const dom = letterDomains[idx];
+    for (let v=0; v<N; v++) if (dom[v]) arr.push(v);
+    return arr;
   }
 
-  function assignKey(idx, value){
-    value = mod(value);
-    if (keyInit[idx] === null){
-      keyInit[idx] = value;
-      return {ok:true, changed:true};
-    }
-    return {ok: keyInit[idx] === value, changed:false};
+  function keyDomainValues(idx){
+    const arr = [];
+    const dom = keyDomains[idx];
+    for (let v=0; v<N; v++) if (dom[v]) arr.push(v);
+    return arr;
   }
 
-  function propagate(){
-    let changed = true;
-    while (changed){
-      changed = false;
-      for (const cons of constraints){
-        if (cons.type === 'init'){
-          const a = pos[cons.pSym];
-          const b = pos[cons.cSym];
-          const keyVal = keyInit[cons.idx];
-          if (a !== null && b !== null){
-            const res = assignKey(cons.idx, b - a);
-            if (!res.ok) return false;
-            if (res.changed) changed = true;
-          }
-          if (a !== null && keyVal !== null){
-            const res = assignLetter(cons.cSym, a + keyVal);
-            if (!res.ok) return false;
-            if (res.changed) changed = true;
-          }
-          if (b !== null && keyVal !== null){
-            const res = assignLetter(cons.pSym, b - keyVal);
-            if (!res.ok) return false;
-            if (res.changed) changed = true;
-          }
-        } else {
-          const a = pos[cons.pSym];
-          const b = pos[cons.cSym];
-          const dep = pos[cons.depSym];
-          if (a !== null && dep !== null){
-            const res = assignLetter(cons.cSym, a + dep);
-            if (!res.ok) return false;
-            if (res.changed) changed = true;
-          }
-          const bNow = pos[cons.cSym];
-          const aNow = pos[cons.pSym];
-          const depNow = pos[cons.depSym];
-          if (bNow !== null && aNow !== null){
-            const res = assignLetter(cons.depSym, bNow - aNow);
-            if (!res.ok) return false;
-            if (res.changed) changed = true;
-          }
-          if (bNow !== null && depNow !== null){
-            const res = assignLetter(cons.pSym, bNow - depNow);
-            if (!res.ok) return false;
-            if (res.changed) changed = true;
-          }
+  function assignLetter(idx, value, ctx){
+    if (idx == null) return { ok:true, changed:false };
+    value = mod(value);
+    const current = pos[idx];
+    if (current !== null){
+      return { ok: current === value, changed:false };
+    }
+    const owner = cipherOwner[value];
+    if (owner !== -1 && owner !== idx) return { ok:false, changed:false };
+    pos[idx] = value;
+    cipherOwner[value] = idx;
+    used[value] = true;
+    const dom = letterDomains[idx];
+    for (let v=0; v<N; v++) dom[v] = (v === value) ? 1 : 0;
+    letterDomainSizes[idx] = 1;
+    if (ctx){
+      for (const consIdx of letterToConstraints[idx]) ctx.enqueue(consIdx);
+    }
+    for (let L=0; L<N; L++){
+      if (L === idx) continue;
+      if (pos[L] !== null) continue;
+      if (letterDomains[L][value]){
+        letterDomains[L][value] = 0;
+        letterDomainSizes[L]--;
+        if (letterDomainSizes[L] <= 0) return { ok:false, changed:true };
+        if (ctx){
+          for (const consIdx of letterToConstraints[L]) ctx.enqueue(consIdx);
         }
       }
+    }
+    return { ok:true, changed:true };
+  }
+
+  function assignKey(idx, value, ctx){
+    if (idx == null) return { ok:true, changed:false };
+    value = mod(value);
+    const current = keyInit[idx];
+    if (current !== null){
+      return { ok: current === value, changed:false };
+    }
+    keyInit[idx] = value;
+    const dom = keyDomains[idx];
+    for (let v=0; v<N; v++) dom[v] = (v === value) ? 1 : 0;
+    keyDomainSizes[idx] = 1;
+    if (ctx){
+      for (const consIdx of keyToConstraints[idx]) ctx.enqueue(consIdx);
+    }
+    return { ok:true, changed:true };
+  }
+
+  function restrictLetterDomain(idx, allowed, ctx){
+    if (idx == null) return { ok:true, changed:false };
+    if (pos[idx] !== null){
+      return { ok: !!allowed[pos[idx]], changed:false };
+    }
+    const dom = letterDomains[idx];
+    let changed = false;
+    let size = letterDomainSizes[idx];
+    for (let v=0; v<N; v++){
+      if (!dom[v]) continue;
+      if (!allowed[v]){
+        dom[v] = 0;
+        size--;
+        changed = true;
+      }
+    }
+    if (size <= 0) return { ok:false, changed:true };
+    if (changed){
+      letterDomainSizes[idx] = size;
+      if (ctx){
+        for (const consIdx of letterToConstraints[idx]) ctx.enqueue(consIdx);
+      }
+    }
+    return { ok:true, changed };
+  }
+
+  function restrictKeyDomain(idx, allowed, ctx){
+    if (idx == null) return { ok:true, changed:false };
+    if (keyInit[idx] !== null){
+      return { ok: !!allowed[keyInit[idx]], changed:false };
+    }
+    const dom = keyDomains[idx];
+    let changed = false;
+    let size = keyDomainSizes[idx];
+    for (let v=0; v<N; v++){
+      if (!dom[v]) continue;
+      if (!allowed[v]){
+        dom[v] = 0;
+        size--;
+        changed = true;
+      }
+    }
+    if (size <= 0) return { ok:false, changed:true };
+    if (changed){
+      keyDomainSizes[idx] = size;
+      if (ctx){
+        for (const consIdx of keyToConstraints[idx]) ctx.enqueue(consIdx);
+      }
+    }
+    return { ok:true, changed };
+  }
+
+  function processInit(cons, ctx){
+    const p = cons.pSym;
+    const c = cons.cSym;
+    const r = cons.idx;
+    const a = pos[p];
+    const b = pos[c];
+    const keyVal = keyInit[r];
+    if (a !== null && b !== null){
+      const res = assignKey(r, b - a, ctx);
+      if (!res.ok) return false;
+    }
+    if (a !== null && keyVal !== null){
+      const res = assignLetter(c, a + keyVal, ctx);
+      if (!res.ok) return false;
+    }
+    if (b !== null && keyVal !== null){
+      const res = assignLetter(p, b - keyVal, ctx);
+      if (!res.ok) return false;
+    }
+    const pVals = a !== null ? [a] : letterDomainValues(p);
+    const cVals = b !== null ? [b] : letterDomainValues(c);
+    const kVals = keyVal !== null ? [keyVal] : keyDomainValues(r);
+    if (!pVals.length || !cVals.length || !kVals.length) return false;
+    if (keyVal === null){
+      const allowedKey = new Array(N).fill(0);
+      for (const pa of pVals){
+        for (const cb of cVals){
+          allowedKey[mod(cb - pa)] = 1;
+        }
+      }
+      const res = restrictKeyDomain(r, allowedKey, ctx);
+      if (!res.ok) return false;
+    }
+    if (a === null){
+      const allowedP = new Array(N).fill(0);
+      for (const cb of cVals){
+        for (const kv of kVals){
+          allowedP[mod(cb - kv)] = 1;
+        }
+      }
+      const res = restrictLetterDomain(p, allowedP, ctx);
+      if (!res.ok) return false;
+    }
+    if (b === null){
+      const allowedC = new Array(N).fill(0);
+      for (const pa of pVals){
+        for (const kv of kVals){
+          allowedC[mod(pa + kv)] = 1;
+        }
+      }
+      const res = restrictLetterDomain(c, allowedC, ctx);
+      if (!res.ok) return false;
     }
     return true;
   }
 
+  function processFeed(cons, ctx){
+    const p = cons.pSym;
+    const c = cons.cSym;
+    const dep = cons.depSym;
+    const a = pos[p];
+    const b = pos[c];
+    const d = pos[dep];
+    if (a !== null && d !== null){
+      const res = assignLetter(c, a + d, ctx);
+      if (!res.ok) return false;
+    }
+    if (b !== null && a !== null){
+      const res = assignLetter(dep, b - a, ctx);
+      if (!res.ok) return false;
+    }
+    if (b !== null && d !== null){
+      const res = assignLetter(p, b - d, ctx);
+      if (!res.ok) return false;
+    }
+    const pVals = a !== null ? [a] : letterDomainValues(p);
+    const cVals = b !== null ? [b] : letterDomainValues(c);
+    const dVals = d !== null ? [d] : letterDomainValues(dep);
+    if (!pVals.length || !cVals.length || !dVals.length) return false;
+    if (b === null){
+      const allowedC = new Array(N).fill(0);
+      for (const pa of pVals){
+        for (const dv of dVals){
+          allowedC[mod(pa + dv)] = 1;
+        }
+      }
+      const res = restrictLetterDomain(c, allowedC, ctx);
+      if (!res.ok) return false;
+    }
+    if (a === null){
+      const allowedP = new Array(N).fill(0);
+      for (const cb of cVals){
+        for (const dv of dVals){
+          allowedP[mod(cb - dv)] = 1;
+        }
+      }
+      const res = restrictLetterDomain(p, allowedP, ctx);
+      if (!res.ok) return false;
+    }
+    if (d === null){
+      const allowedD = new Array(N).fill(0);
+      for (const cb of cVals){
+        for (const pa of pVals){
+          allowedD[mod(cb - pa)] = 1;
+        }
+      }
+      const res = restrictLetterDomain(dep, allowedD, ctx);
+      if (!res.ok) return false;
+    }
+    return true;
+  }
+
+  function propagate(){
+    const pending = new Array(constraints.length).fill(false);
+    const queue = [];
+    const ctx = {
+      enqueue(idx){
+        if (idx == null) return;
+        if (!pending[idx]){
+          pending[idx] = true;
+          queue.push(idx);
+        }
+      }
+    };
+    if (anchor != null && pos[anchor] === null){
+      const res = assignLetter(anchor, anchorValue, ctx);
+      if (!res.ok) return false;
+    }
+    for (let i=0; i<constraints.length; i++) ctx.enqueue(i);
+    while (true){
+      while (queue.length){
+        const idx = queue.pop();
+        pending[idx] = false;
+        const cons = constraints[idx];
+        const ok = cons.type === 'init' ? processInit(cons, ctx) : processFeed(cons, ctx);
+        if (!ok) return false;
+      }
+      let assigned = false;
+      for (let L=0; L<N; L++){
+        if (pos[L] === null){
+          if (letterDomainSizes[L] === 0) return false;
+          if (letterDomainSizes[L] === 1){
+            const vals = letterDomainValues(L);
+            if (!vals.length) return false;
+            const res = assignLetter(L, vals[0], ctx);
+            if (!res.ok) return false;
+            assigned = true;
+          }
+        }
+      }
+      for (let r=0; r<mLen; r++){
+        if (keyInit[r] === null){
+          if (keyDomainSizes[r] === 0) return false;
+          if (keyDomainSizes[r] === 1){
+            const vals = keyDomainValues(r);
+            if (!vals.length) return false;
+            const res = assignKey(r, vals[0], ctx);
+            if (!res.ok) return false;
+            assigned = true;
+          }
+        }
+      }
+      if (!assigned) break;
+    }
+    return true;
+  }
+
+  function isSolved(){
+    for (let L=0; L<N; L++) if (pos[L] === null) return false;
+    for (let r=0; r<mLen; r++) if (keyInit[r] === null) return false;
+    return true;
+  }
+
   function chooseVar(){
-    let bestLetter=-1, bestScore=-1;
+    let bestLetter = -1;
+    let bestLetterScore = Infinity;
+    let bestLetterWeight = -Infinity;
     for (let L=0; L<N; L++){
-      if (pos[L]===null && letterDeg[L]>bestScore){
-        bestScore = letterDeg[L];
+      if (pos[L] !== null) continue;
+      const size = letterDomainSizes[L];
+      if (size <= 0) return { type:'letter', idx:L };
+      const weight = (letterFeedDeg[L] || 0) * 2 + (letterDeg[L] || 0);
+      if (size < bestLetterScore || (size === bestLetterScore && weight > bestLetterWeight)){
         bestLetter = L;
+        bestLetterScore = size;
+        bestLetterWeight = weight;
       }
     }
-    if (bestLetter !== -1 && bestScore>0) return {type:'letter', idx:bestLetter};
-    let bestKey=-1, bestKeyScore=-1;
-    for (let i=0;i<m;i++){
-      if (keyInit[i]===null && keyDeg[i]>bestKeyScore){
-        bestKeyScore = keyDeg[i];
-        bestKey = i;
+    if (bestLetter !== -1) return { type:'letter', idx: bestLetter };
+    let bestKey = -1;
+    let bestKeyScore = Infinity;
+    let bestKeyWeight = -Infinity;
+    for (let r=0; r<mLen; r++){
+      if (keyInit[r] !== null) continue;
+      const size = keyDomainSizes[r];
+      if (size <= 0) return { type:'key', idx:r };
+      const weight = keyDeg[r] || 0;
+      if (size < bestKeyScore || (size === bestKeyScore && weight > bestKeyWeight)){
+        bestKey = r;
+        bestKeyScore = size;
+        bestKeyWeight = weight;
       }
     }
-    if (bestKey !== -1 && bestKeyScore>0) return {type:'key', idx:bestKey};
+    if (bestKey !== -1) return { type:'key', idx: bestKey };
     return null;
   }
 
   function snapshot(){
-    return { pos: pos.slice(), used: used.slice(), key: keyInit.slice() };
+    return {
+      pos: pos.slice(),
+      used: used.slice(),
+      cipherOwner: cipherOwner.slice(),
+      keyInit: keyInit.slice(),
+      letterDomains: letterDomains.map(arr => arr.slice()),
+      letterDomainSizes: letterDomainSizes.slice(),
+      keyDomains: keyDomains.map(arr => arr.slice()),
+      keyDomainSizes: keyDomainSizes.slice()
+    };
   }
+
   function restore(state){
-    for (let i=0;i<N;i++){ pos[i]=state.pos[i]; used[i]=state.used[i]; }
-    for (let i=0;i<m;i++){ keyInit[i]=state.key[i]; }
+    for (let i=0; i<N; i++){
+      pos[i] = state.pos[i];
+      used[i] = state.used[i];
+      cipherOwner[i] = state.cipherOwner[i];
+      const destDom = letterDomains[i];
+      const srcDom = state.letterDomains[i];
+      for (let v=0; v<N; v++) destDom[v] = srcDom[v];
+    }
+    for (let r=0; r<mLen; r++){
+      keyInit[r] = state.keyInit[r];
+      keyDomainSizes[r] = state.keyDomainSizes[r];
+      const destDom = keyDomains[r];
+      const srcDom = state.keyDomains[r];
+      for (let v=0; v<N; v++) destDom[v] = srcDom[v];
+    }
+    for (let L=0; L<N; L++){
+      letterDomainSizes[L] = state.letterDomainSizes[L];
+    }
   }
+
+  function finalizeSolution(){
+    const posFull = pos.slice();
+    const usedValues = new Array(N).fill(false);
+    for (let L=0; L<N; L++){
+      const v = posFull[L];
+      if (v !== null) usedValues[v] = true;
+    }
+    const remaining = [];
+    for (let v=0; v<N; v++) if (!usedValues[v]) remaining.push(v);
+    for (let L=0; L<N; L++){
+      if (posFull[L] === null){
+        const next = remaining.length ? remaining.shift() : 0;
+        posFull[L] = next;
+      }
+    }
+    const keyFull = keyInit.slice();
+    for (let r=0; r<mLen; r++) keyFull[r] = mod(keyFull[r] == null ? 0 : keyFull[r]);
+    return { pos: posFull, k: keyFull };
+  }
+
+  function stateKey(){
+    let out = '';
+    for (let L=0; L<N; L++) out += pos[L] === null ? '_' : pos[L].toString(36);
+    out += '|';
+    for (let r=0; r<mLen; r++) out += keyInit[r] === null ? '_' : keyInit[r].toString(36);
+    return out;
+  }
+
+  const memo = new Set();
+  let dfsNodes = 0;
+  let lastPing = typeof performance !== 'undefined' ? performance.now() : 0;
 
   function dfs(){
     if (!propagate()) return null;
+    if (isSolved()) return finalizeSolution();
+    const memoKey = stateKey();
+    if (memo.has(memoKey)) return null;
     const sel = chooseVar();
-    if (!sel){
-      const posFull = pos.slice();
-      const free = [];
-      for (let v=0; v<N; v++){ if (!used[v]) free.push(v); }
-      for (let L=0; L<N; L++){ if (posFull[L]===null) posFull[L] = free.shift(); }
-      const keyFull = keyInit.slice().map(x => x===null ? 0 : mod(x));
-      return { pos: posFull, k: keyFull };
+    if (!sel) return finalizeSolution();
+    dfsNodes++;
+    if (progressCb && dfsNodes % 500 === 0){
+      const now = typeof performance !== 'undefined' ? performance.now() : 0;
+      if (!lastPing || now - lastPing > 120){
+        lastPing = now;
+        progressCb({ kind:'dfs', nodes: dfsNodes });
+      }
     }
     if (sel.type === 'letter'){
-      const candSet = new Set();
-      for (const cons of constraints){
-        if (cons.pSym === sel.idx){
-          if (cons.type === 'init'){
-            const b = pos[cons.cSym];
-            const keyVal = keyInit[cons.idx];
-            if (b !== null && keyVal !== null) candSet.add(mod(b - keyVal));
-          } else {
-            const b = pos[cons.cSym];
-            const dep = pos[cons.depSym];
-            if (b !== null && dep !== null) candSet.add(mod(b - dep));
-          }
-        }
-        if (cons.cSym === sel.idx){
-          if (cons.type === 'init'){
-            const a = pos[cons.pSym];
-            const keyVal = keyInit[cons.idx];
-            if (a !== null && keyVal !== null) candSet.add(mod(a + keyVal));
-          } else {
-            const a = pos[cons.pSym];
-            const dep = pos[cons.depSym];
-            if (a !== null && dep !== null) candSet.add(mod(a + dep));
-          }
-        }
-        if (cons.type === 'feed' && cons.depSym === sel.idx){
-          const a = pos[cons.pSym];
-          const b = pos[cons.cSym];
-          if (b !== null && a !== null) candSet.add(mod(b - a));
-        }
-      }
-      const free = [];
-      for (let v=0; v<N; v++){ if (!used[v]) free.push(v); }
-      const candidates = candSet.size ? Array.from(candSet).filter(v => !used[v]) : free;
-      for (const val of candidates){
+      const domain = letterDomainValues(sel.idx);
+      domain.sort((a,b)=>a-b);
+      for (const val of domain){
         const snap = snapshot();
-        const vv = mod(val);
-        pos[sel.idx] = vv;
-        used[vv] = true;
-        const res = dfs();
-        if (res) return res;
+        const res = assignLetter(sel.idx, val, null);
+        if (!res.ok){ restore(snap); continue; }
+        const out = dfs();
+        if (out) return out;
         restore(snap);
       }
     } else {
-      const candSet = new Set();
-      for (const cons of constraints){
-        if (cons.type === 'init' && cons.idx === sel.idx){
-          const a = pos[cons.pSym];
-          const b = pos[cons.cSym];
-          if (a !== null && b !== null) candSet.add(mod(b - a));
-        }
-      }
-      const candidates = candSet.size ? Array.from(candSet) : [...Array(N).keys()];
-      for (const val of candidates){
+      const domain = keyDomainValues(sel.idx);
+      domain.sort((a,b)=>a-b);
+      for (const val of domain){
         const snap = snapshot();
-        keyInit[sel.idx] = mod(val);
-        const res = dfs();
-        if (res) return res;
+        const res = assignKey(sel.idx, val, null);
+        if (!res.ok){ restore(snap); continue; }
+        const out = dfs();
+        if (out) return out;
         restore(snap);
       }
     }
+    memo.add(memoKey);
     return null;
   }
 
-  if (options && options.propagateOnly){
-    return propagate();
+  if (propagateOnly){
+    if (!propagate()) return false;
+    if (isSolved()) return true;
+    if (MAX_TRIALS <= 0 || TRIAL_DEPTH <= 0) return false;
+    const baseline = snapshot();
+    for (let t=0; t<MAX_TRIALS; t++){
+      restore(baseline);
+      let success = true;
+      for (let depth=0; depth<TRIAL_DEPTH; depth++){
+        const sel = chooseVar();
+        if (!sel) break;
+        const domain = sel.type === 'letter' ? letterDomainValues(sel.idx) : keyDomainValues(sel.idx);
+        if (!domain.length){ success = false; break; }
+        const tries = Math.min(3, domain.length);
+        let progressed = false;
+        for (let i=0; i<tries; i++){
+          const val = domain[(t + depth + i) % domain.length];
+          const snap = snapshot();
+          const res = sel.type === 'letter' ? assignLetter(sel.idx, val, null) : assignKey(sel.idx, val, null);
+          if (!res.ok){ restore(snap); continue; }
+          if (!propagate()){ restore(snap); continue; }
+          progressed = true;
+          break;
+        }
+        if (!progressed){ success = false; break; }
+      }
+      if (success){
+        if (isSolved()) return true;
+        if (propagate()) return true;
+      }
+    }
+    return false;
   }
 
-  return dfs();
-}
-
-
-function decryptWithCustomAlphabet(letters, pos, k){
-  const N=26;
-  const inv=new Array(N); for (let L=0;L<N;L++) inv[pos[L]] = A[L];
-  let out=''; let step=0;
-  for (let i=0;i<letters.length;i++){
-    const ch=letters[i];
-    if (!isLetter(ch)){ out+=ch; continue; }
-    const cIdx = pos[A2I[ch.toUpperCase()]];
-    const pIdx = ((cIdx - k[step % k.length]) % N + N) % N;
-    out += inv[pIdx];
-    step++;
-  }
-  return out;
+  const sol = dfs();
+  if (!sol) return null;
+  return sol;
 }
 
 function decryptAutokeyUnknownAlphabet(letters, pos, keyInit){
@@ -1823,6 +2202,142 @@ try{
           }
           return segments;
         }
+        function buildAutokeyStepAssignments(letters, cribMap){
+          const { absToLetterStep } = buildLetterStreams(letters);
+          const segments = collectContiguousCribs(letters, cribMap);
+          const stepPlain = new Map();
+          const stepCipher = new Map();
+          let conflict = false;
+          for (const seg of segments){
+            const startStep = absToLetterStep[seg.start];
+            if (startStep == null || startStep < 0) continue;
+            for (let t=0; t<seg.cipherSeg.length; t++){
+              const step = startStep + t;
+              const pSym = A2I[seg.plainSeg[t]];
+              const cSym = A2I[seg.cipherSeg[t]];
+              if (stepPlain.has(step) && stepPlain.get(step) !== pSym){ conflict = true; break; }
+              if (stepCipher.has(step) && stepCipher.get(step) !== cSym){ conflict = true; break; }
+              stepPlain.set(step, pSym);
+              stepCipher.set(step, cSym);
+            }
+            if (conflict) break;
+          }
+          return { stepPlain, stepCipher, conflict };
+        }
+
+        function extendAutokeyAssignments(baseAssignments, letters, word, startStep, stepToAbs){
+          const stepPlain = new Map(baseAssignments ? baseAssignments.stepPlain : []);
+          const stepCipher = new Map(baseAssignments ? baseAssignments.stepCipher : []);
+          let conflict = baseAssignments ? !!baseAssignments.conflict : false;
+          if (conflict){
+            return { stepPlain, stepCipher, conflict:true };
+          }
+          for (let t=0; t<word.length; t++){
+            const step = startStep + t;
+            const absPos = stepToAbs[step];
+            if (absPos == null || absPos < 0) continue;
+            const cipherCh = letters[absPos];
+            if (!isLetter(cipherCh)) continue;
+            const pSym = A2I[word[t]];
+            const cSym = A2I[cipherCh.toUpperCase()];
+            if (stepPlain.has(step) && stepPlain.get(step) !== pSym) return { stepPlain, stepCipher, conflict:true };
+            if (stepCipher.has(step) && stepCipher.get(step) !== cSym) return { stepPlain, stepCipher, conflict:true };
+            stepPlain.set(step, pSym);
+            stepCipher.set(step, cSym);
+          }
+          return { stepPlain, stepCipher, conflict:false };
+        }
+
+        function prepareAutokeyBaseState(assignments, m){
+          const N = 26;
+          if (!assignments || assignments.conflict) return null;
+          if (!Number.isFinite(m) || m <= 0) return null;
+          const stepPlain = assignments.stepPlain;
+          const stepCipher = assignments.stepCipher;
+          if (!stepPlain || !stepPlain.size) return null;
+          const constraints = [];
+          const letterDeg = new Array(N).fill(0);
+          const letterFeedDeg = new Array(N).fill(0);
+          const keyDeg = new Array(m).fill(0);
+          const steps = Array.from(stepPlain.keys()).sort((a,b)=>a-b);
+          for (const step of steps){
+            const pSym = stepPlain.get(step);
+            const cSym = stepCipher.get(step);
+            if (pSym == null || cSym == null) continue;
+            if (step < m){
+              constraints.push({ type:'init', idx:step, pSym, cSym });
+              keyDeg[step]++;
+            }
+            const depStep = step - m;
+            if (depStep >= 0 && stepPlain.has(depStep)){
+              const depSym = stepPlain.get(depStep);
+              constraints.push({ type:'feed', idx:step, pSym, cSym, depSym });
+              letterFeedDeg[depSym]++;
+            }
+            letterDeg[pSym]++;
+            letterDeg[cSym]++;
+          }
+          if (!constraints.length) return null;
+          const letterToConstraints = Array.from({length:N}, ()=>[]);
+          const keyToConstraints = Array.from({length:m}, ()=>[]);
+          constraints.forEach((cons, idx)=>{
+            letterToConstraints[cons.pSym].push(idx);
+            letterToConstraints[cons.cSym].push(idx);
+            if (cons.type === 'feed') letterToConstraints[cons.depSym].push(idx);
+            if (cons.type === 'init') keyToConstraints[cons.idx].push(idx);
+          });
+          const base = {
+            m,
+            constraints,
+            letterDeg,
+            letterFeedDeg,
+            keyDeg,
+            letterToConstraints,
+            keyToConstraints,
+            stepPlain,
+            stepCipher
+          };
+          base.posTemplate = new Array(N).fill(null);
+          base.usedTemplate = new Array(N).fill(false);
+          base.cipherOwnerTemplate = new Array(N).fill(-1);
+          base.keyTemplate = new Array(m).fill(null);
+          base.letterDomainsTemplate = Array.from({length:N}, ()=>Array(N).fill(1));
+          base.letterDomainSizesTemplate = new Array(N).fill(N);
+          base.keyDomainsTemplate = Array.from({length:m}, ()=>Array(N).fill(1));
+          base.keyDomainSizesTemplate = new Array(m).fill(N);
+          let anchor=-1, bestScore=-1;
+          for (let L=0; L<N; L++){
+            const deg = letterDeg[L];
+            if (!deg) continue;
+            const score = deg * 8 + (letterFeedDeg[L] || 0);
+            if (score > bestScore){ bestScore = score; anchor = L; }
+          }
+          if (anchor !== -1){
+            base.anchor = anchor;
+            base.anchorValue = 0;
+            base.posTemplate[anchor] = 0;
+            base.usedTemplate[0] = true;
+            base.cipherOwnerTemplate[0] = anchor;
+            const dom = base.letterDomainsTemplate[anchor];
+            for (let i=0; i<N; i++) dom[i] = (i === 0) ? 1 : 0;
+            base.letterDomainSizesTemplate[anchor] = 1;
+          }
+          return base;
+        }
+
+        function instantiateAutokeyState(base){
+          return {
+            pos: base.posTemplate.slice(),
+            used: base.usedTemplate.slice(),
+            cipherOwner: base.cipherOwnerTemplate.slice(),
+            keyInit: base.keyTemplate.slice(),
+            letterDomains: base.letterDomainsTemplate.map(arr => arr.slice()),
+            letterDomainSizes: base.letterDomainSizesTemplate.slice(),
+            keyDomains: base.keyDomainsTemplate.map(arr => arr.slice()),
+            keyDomainSizes: base.keyDomainSizesTemplate.slice()
+          };
+        }
+
         function englishFitness(upArr){
           const FREQ = {'E':12.0,'T':9.1,'A':8.2,'O':7.5,'I':7.0,'N':6.7,'S':6.3,'R':6.0,'H':6.1,'L':4.0,'D':4.3,'C':2.8,'U':2.8,'M':2.4,'F':2.2,'Y':2.0,'W':2.4,'G':2.0,'P':1.9,'B':1.5,'V':1.0,'K':0.8,'X':0.2,'Q':0.1,'J':0.15,'Z':0.07};
           const n = upArr.length||1;
@@ -1982,238 +2497,518 @@ try{
           }
           return out;
         }
-        function solveAutokeyUnknownAlphabet(letters, cribMap, m){
+        function solveAutokeyUnknownAlphabet(letters, cribMap, m, options){
           const N = 26;
           if (!Number.isFinite(m) || m <= 0) return null;
-          const segments = collectContiguousCribs(letters, cribMap);
-          if (!segments.length) return null;
-          const { absToLetterStep } = buildLetterStreams(letters);
-          const stepPlain = new Map();
-          const stepCipher = new Map();
-          for (const seg of segments){
-            const startStep = absToLetterStep[seg.start];
-            if (startStep == null || startStep < 0) continue;
-            for (let t=0; t<seg.cipherSeg.length; t++){
-              const step = startStep + t;
-              const pSym = A2I[seg.plainSeg[t]];
-              const cSym = A2I[seg.cipherSeg[t]];
-              if (stepPlain.has(step) && stepPlain.get(step) !== pSym) return null;
-              if (stepCipher.has(step) && stepCipher.get(step) !== cSym) return null;
-              stepPlain.set(step, pSym);
-              stepCipher.set(step, cSym);
-            }
+          options = options || {};
+          let base = options.baseState;
+          if (!base){
+            const assignments = buildAutokeyStepAssignments(letters, cribMap);
+            if (!assignments || assignments.conflict) return null;
+            if (!assignments.stepPlain || !assignments.stepPlain.size) return null;
+            base = prepareAutokeyBaseState(assignments, m);
+            if (!base) return null;
+          } else if (base.m !== m){
+            return null;
           }
-          if (!stepPlain.size) return null;
+          const propagateOnly = !!options.propagateOnly;
+          const MAX_TRIALS = Number.isFinite(options.quickTrials) ? Math.max(0, options.quickTrials|0) : 30;
+          const TRIAL_DEPTH = Number.isFinite(options.trialDepth) ? Math.max(0, options.trialDepth|0) : 3;
+          const progressCb = options.progressCb;
 
-          const constraints = [];
-          const letterDeg = new Array(N).fill(0);
-          const keyDeg = new Array(m).fill(0);
-          const steps = Array.from(stepPlain.keys()).sort((a,b)=>a-b);
-          for (const step of steps){
-            const pSym = stepPlain.get(step);
-            const cSym = stepCipher.get(step);
-            if (pSym == null || cSym == null) continue;
-            if (step < m){
-              constraints.push({ type:'init', idx:step, pSym, cSym });
-              keyDeg[step]++;
-            }
-            const depStep = step - m;
-            if (depStep >= 0 && stepPlain.has(depStep)){
-              const depSym = stepPlain.get(depStep);
-              constraints.push({ type:'feed', idx:step, pSym, cSym, depSym });
-              letterDeg[depSym]++;
-            }
-            letterDeg[pSym]++;
-            letterDeg[cSym]++;
-          }
-          if (!constraints.length) return null;
+          const state = instantiateAutokeyState(base);
+          const pos = state.pos;
+          const used = state.used;
+          const cipherOwner = state.cipherOwner;
+          const keyInit = state.keyInit;
+          const letterDomains = state.letterDomains;
+          const letterDomainSizes = state.letterDomainSizes;
+          const keyDomains = state.keyDomains;
+          const keyDomainSizes = state.keyDomainSizes;
 
-          const pos = new Array(N).fill(null);
-          const used = new Array(N).fill(false);
-          const keyInit = new Array(m).fill(null);
+          const constraints = base.constraints;
+          if (!constraints || !constraints.length) return null;
+          const letterToConstraints = base.letterToConstraints;
+          const keyToConstraints = base.keyToConstraints;
+          const letterDeg = base.letterDeg;
+          const letterFeedDeg = base.letterFeedDeg || new Array(N).fill(0);
+          const keyDeg = base.keyDeg;
+          const anchor = base.anchor;
+          const anchorValue = base.anchorValue || 0;
+          const mLen = base.m;
+
           const mod = (x)=>((x%N)+N)%N;
 
-          function assignLetter(idx, value){
-            if (idx == null) return {ok:true, changed:false};
-            value = mod(value);
-            if (pos[idx] === null){
-              if (used[value]) return {ok:false, changed:false};
-              pos[idx] = value;
-              used[value] = true;
-              return {ok:true, changed:true};
-            }
-            return {ok: pos[idx] === value, changed:false};
+          function letterDomainValues(idx){
+            const arr = [];
+            const dom = letterDomains[idx];
+            for (let v=0; v<N; v++) if (dom[v]) arr.push(v);
+            return arr;
           }
 
-          function assignKey(idx, value){
-            value = mod(value);
-            if (keyInit[idx] === null){
-              keyInit[idx] = value;
-              return {ok:true, changed:true};
-            }
-            return {ok: keyInit[idx] === value, changed:false};
+          function keyDomainValues(idx){
+            const arr = [];
+            const dom = keyDomains[idx];
+            for (let v=0; v<N; v++) if (dom[v]) arr.push(v);
+            return arr;
           }
 
-          function propagate(){
-            let changed = true;
-            while (changed){
-              changed = false;
-              for (const cons of constraints){
-                if (cons.type === 'init'){
-                  const a = pos[cons.pSym];
-                  const b = pos[cons.cSym];
-                  const keyVal = keyInit[cons.idx];
-                  if (a !== null && b !== null){
-                    const res = assignKey(cons.idx, b - a);
-                    if (!res.ok) return false;
-                    if (res.changed) changed = true;
-                  }
-                  if (a !== null && keyVal !== null){
-                    const res = assignLetter(cons.cSym, a + keyVal);
-                    if (!res.ok) return false;
-                    if (res.changed) changed = true;
-                  }
-                  if (b !== null && keyVal !== null){
-                    const res = assignLetter(cons.pSym, b - keyVal);
-                    if (!res.ok) return false;
-                    if (res.changed) changed = true;
-                  }
-                } else {
-                  const a = pos[cons.pSym];
-                  const b = pos[cons.cSym];
-                  const dep = pos[cons.depSym];
-                  if (a !== null && dep !== null){
-                    const res = assignLetter(cons.cSym, a + dep);
-                    if (!res.ok) return false;
-                    if (res.changed) changed = true;
-                  }
-                  const bNow = pos[cons.cSym];
-                  const aNow = pos[cons.pSym];
-                  const depNow = pos[cons.depSym];
-                  if (bNow !== null && aNow !== null){
-                    const res = assignLetter(cons.depSym, bNow - aNow);
-                    if (!res.ok) return false;
-                    if (res.changed) changed = true;
-                  }
-                  if (bNow !== null && depNow !== null){
-                    const res = assignLetter(cons.pSym, bNow - depNow);
-                    if (!res.ok) return false;
-                    if (res.changed) changed = true;
-                  }
+          function assignLetter(idx, value, ctx){
+            if (idx == null) return { ok:true, changed:false };
+            value = mod(value);
+            const current = pos[idx];
+            if (current !== null){
+              return { ok: current === value, changed:false };
+            }
+            const owner = cipherOwner[value];
+            if (owner !== -1 && owner !== idx) return { ok:false, changed:false };
+            pos[idx] = value;
+            cipherOwner[value] = idx;
+            used[value] = true;
+            const dom = letterDomains[idx];
+            for (let v=0; v<N; v++) dom[v] = (v === value) ? 1 : 0;
+            letterDomainSizes[idx] = 1;
+            if (ctx){
+              for (const consIdx of letterToConstraints[idx]) ctx.enqueue(consIdx);
+            }
+            for (let L=0; L<N; L++){
+              if (L === idx) continue;
+              if (pos[L] !== null) continue;
+              if (letterDomains[L][value]){
+                letterDomains[L][value] = 0;
+                letterDomainSizes[L]--;
+                if (letterDomainSizes[L] <= 0) return { ok:false, changed:true };
+                if (ctx){
+                  for (const consIdx of letterToConstraints[L]) ctx.enqueue(consIdx);
                 }
               }
+            }
+            return { ok:true, changed:true };
+          }
+
+          function assignKey(idx, value, ctx){
+            if (idx == null) return { ok:true, changed:false };
+            value = mod(value);
+            const current = keyInit[idx];
+            if (current !== null){
+              return { ok: current === value, changed:false };
+            }
+            keyInit[idx] = value;
+            const dom = keyDomains[idx];
+            for (let v=0; v<N; v++) dom[v] = (v === value) ? 1 : 0;
+            keyDomainSizes[idx] = 1;
+            if (ctx){
+              for (const consIdx of keyToConstraints[idx]) ctx.enqueue(consIdx);
+            }
+            return { ok:true, changed:true };
+          }
+
+          function restrictLetterDomain(idx, allowed, ctx){
+            if (idx == null) return { ok:true, changed:false };
+            if (pos[idx] !== null){
+              return { ok: !!allowed[pos[idx]], changed:false };
+            }
+            const dom = letterDomains[idx];
+            let changed = false;
+            let size = letterDomainSizes[idx];
+            for (let v=0; v<N; v++){
+              if (!dom[v]) continue;
+              if (!allowed[v]){
+                dom[v] = 0;
+                size--;
+                changed = true;
+              }
+            }
+            if (size <= 0) return { ok:false, changed:true };
+            if (changed){
+              letterDomainSizes[idx] = size;
+              if (ctx){
+                for (const consIdx of letterToConstraints[idx]) ctx.enqueue(consIdx);
+              }
+            }
+            return { ok:true, changed };
+          }
+
+          function restrictKeyDomain(idx, allowed, ctx){
+            if (idx == null) return { ok:true, changed:false };
+            if (keyInit[idx] !== null){
+              return { ok: !!allowed[keyInit[idx]], changed:false };
+            }
+            const dom = keyDomains[idx];
+            let changed = false;
+            let size = keyDomainSizes[idx];
+            for (let v=0; v<N; v++){
+              if (!dom[v]) continue;
+              if (!allowed[v]){
+                dom[v] = 0;
+                size--;
+                changed = true;
+              }
+            }
+            if (size <= 0) return { ok:false, changed:true };
+            if (changed){
+              keyDomainSizes[idx] = size;
+              if (ctx){
+                for (const consIdx of keyToConstraints[idx]) ctx.enqueue(consIdx);
+              }
+            }
+            return { ok:true, changed };
+          }
+
+          function processInit(cons, ctx){
+            const p = cons.pSym;
+            const c = cons.cSym;
+            const r = cons.idx;
+            const a = pos[p];
+            const b = pos[c];
+            const keyVal = keyInit[r];
+            if (a !== null && b !== null){
+              const res = assignKey(r, b - a, ctx);
+              if (!res.ok) return false;
+            }
+            if (a !== null && keyVal !== null){
+              const res = assignLetter(c, a + keyVal, ctx);
+              if (!res.ok) return false;
+            }
+            if (b !== null && keyVal !== null){
+              const res = assignLetter(p, b - keyVal, ctx);
+              if (!res.ok) return false;
+            }
+            const pVals = a !== null ? [a] : letterDomainValues(p);
+            const cVals = b !== null ? [b] : letterDomainValues(c);
+            const kVals = keyVal !== null ? [keyVal] : keyDomainValues(r);
+            if (!pVals.length || !cVals.length || !kVals.length) return false;
+            if (keyVal === null){
+              const allowedKey = new Array(N).fill(0);
+              for (const pa of pVals){
+                for (const cb of cVals){
+                  allowedKey[mod(cb - pa)] = 1;
+                }
+              }
+              const res = restrictKeyDomain(r, allowedKey, ctx);
+              if (!res.ok) return false;
+            }
+            if (a === null){
+              const allowedP = new Array(N).fill(0);
+              for (const cb of cVals){
+                for (const kv of kVals){
+                  allowedP[mod(cb - kv)] = 1;
+                }
+              }
+              const res = restrictLetterDomain(p, allowedP, ctx);
+              if (!res.ok) return false;
+            }
+            if (b === null){
+              const allowedC = new Array(N).fill(0);
+              for (const pa of pVals){
+                for (const kv of kVals){
+                  allowedC[mod(pa + kv)] = 1;
+                }
+              }
+              const res = restrictLetterDomain(c, allowedC, ctx);
+              if (!res.ok) return false;
             }
             return true;
           }
 
+          function processFeed(cons, ctx){
+            const p = cons.pSym;
+            const c = cons.cSym;
+            const dep = cons.depSym;
+            const a = pos[p];
+            const b = pos[c];
+            const d = pos[dep];
+            if (a !== null && d !== null){
+              const res = assignLetter(c, a + d, ctx);
+              if (!res.ok) return false;
+            }
+            if (b !== null && a !== null){
+              const res = assignLetter(dep, b - a, ctx);
+              if (!res.ok) return false;
+            }
+            if (b !== null && d !== null){
+              const res = assignLetter(p, b - d, ctx);
+              if (!res.ok) return false;
+            }
+            const pVals = a !== null ? [a] : letterDomainValues(p);
+            const cVals = b !== null ? [b] : letterDomainValues(c);
+            const dVals = d !== null ? [d] : letterDomainValues(dep);
+            if (!pVals.length || !cVals.length || !dVals.length) return false;
+            if (b === null){
+              const allowedC = new Array(N).fill(0);
+              for (const pa of pVals){
+                for (const dv of dVals){
+                  allowedC[mod(pa + dv)] = 1;
+                }
+              }
+              const res = restrictLetterDomain(c, allowedC, ctx);
+              if (!res.ok) return false;
+            }
+            if (a === null){
+              const allowedP = new Array(N).fill(0);
+              for (const cb of cVals){
+                for (const dv of dVals){
+                  allowedP[mod(cb - dv)] = 1;
+                }
+              }
+              const res = restrictLetterDomain(p, allowedP, ctx);
+              if (!res.ok) return false;
+            }
+            if (d === null){
+              const allowedD = new Array(N).fill(0);
+              for (const cb of cVals){
+                for (const pa of pVals){
+                  allowedD[mod(cb - pa)] = 1;
+                }
+              }
+              const res = restrictLetterDomain(dep, allowedD, ctx);
+              if (!res.ok) return false;
+            }
+            return true;
+          }
+
+          function propagate(){
+            const pending = new Array(constraints.length).fill(false);
+            const queue = [];
+            const ctx = {
+              enqueue(idx){
+                if (idx == null) return;
+                if (!pending[idx]){
+                  pending[idx] = true;
+                  queue.push(idx);
+                }
+              }
+            };
+            if (anchor != null && pos[anchor] === null){
+              const res = assignLetter(anchor, anchorValue, ctx);
+              if (!res.ok) return false;
+            }
+            for (let i=0; i<constraints.length; i++) ctx.enqueue(i);
+            while (true){
+              while (queue.length){
+                const idx = queue.pop();
+                pending[idx] = false;
+                const cons = constraints[idx];
+                const ok = cons.type === 'init' ? processInit(cons, ctx) : processFeed(cons, ctx);
+                if (!ok) return false;
+              }
+              let assigned = false;
+              for (let L=0; L<N; L++){
+                if (pos[L] === null){
+                  if (letterDomainSizes[L] === 0) return false;
+                  if (letterDomainSizes[L] === 1){
+                    const vals = letterDomainValues(L);
+                    if (!vals.length) return false;
+                    const res = assignLetter(L, vals[0], ctx);
+                    if (!res.ok) return false;
+                    assigned = true;
+                  }
+                }
+              }
+              for (let r=0; r<mLen; r++){
+                if (keyInit[r] === null){
+                  if (keyDomainSizes[r] === 0) return false;
+                  if (keyDomainSizes[r] === 1){
+                    const vals = keyDomainValues(r);
+                    if (!vals.length) return false;
+                    const res = assignKey(r, vals[0], ctx);
+                    if (!res.ok) return false;
+                    assigned = true;
+                  }
+                }
+              }
+              if (!assigned) break;
+            }
+            return true;
+          }
+
+          function isSolved(){
+            for (let L=0; L<N; L++) if (pos[L] === null) return false;
+            for (let r=0; r<mLen; r++) if (keyInit[r] === null) return false;
+            return true;
+          }
+
           function chooseVar(){
-            let bestLetter=-1, bestScore=-1;
+            let bestLetter = -1;
+            let bestLetterScore = Infinity;
+            let bestLetterWeight = -Infinity;
             for (let L=0; L<N; L++){
-              if (pos[L]===null && letterDeg[L]>bestScore){
-                bestScore = letterDeg[L];
+              if (pos[L] !== null) continue;
+              const size = letterDomainSizes[L];
+              if (size <= 0) return { type:'letter', idx:L };
+              const weight = (letterFeedDeg[L] || 0) * 2 + (letterDeg[L] || 0);
+              if (size < bestLetterScore || (size === bestLetterScore && weight > bestLetterWeight)){
                 bestLetter = L;
+                bestLetterScore = size;
+                bestLetterWeight = weight;
               }
             }
-            if (bestLetter !== -1 && bestScore>0) return {type:'letter', idx:bestLetter};
-            let bestKey=-1, bestKeyScore=-1;
-            for (let i=0;i<m;i++){
-              if (keyInit[i]===null && keyDeg[i]>bestKeyScore){
-                bestKeyScore = keyDeg[i];
-                bestKey = i;
+            if (bestLetter !== -1) return { type:'letter', idx: bestLetter };
+            let bestKey = -1;
+            let bestKeyScore = Infinity;
+            let bestKeyWeight = -Infinity;
+            for (let r=0; r<mLen; r++){
+              if (keyInit[r] !== null) continue;
+              const size = keyDomainSizes[r];
+              if (size <= 0) return { type:'key', idx:r };
+              const weight = keyDeg[r] || 0;
+              if (size < bestKeyScore || (size === bestKeyScore && weight > bestKeyWeight)){
+                bestKey = r;
+                bestKeyScore = size;
+                bestKeyWeight = weight;
               }
             }
-            if (bestKey !== -1 && bestKeyScore>0) return {type:'key', idx:bestKey};
+            if (bestKey !== -1) return { type:'key', idx: bestKey };
             return null;
           }
 
           function snapshot(){
-            return { pos: pos.slice(), used: used.slice(), key: keyInit.slice() };
-          }
-          function restore(state){
-            for (let i=0;i<N;i++){ pos[i]=state.pos[i]; used[i]=state.used[i]; }
-            for (let i=0;i<m;i++){ keyInit[i]=state.key[i]; }
+            return {
+              pos: pos.slice(),
+              used: used.slice(),
+              cipherOwner: cipherOwner.slice(),
+              keyInit: keyInit.slice(),
+              letterDomains: letterDomains.map(arr => arr.slice()),
+              letterDomainSizes: letterDomainSizes.slice(),
+              keyDomains: keyDomains.map(arr => arr.slice()),
+              keyDomainSizes: keyDomainSizes.slice()
+            };
           }
 
+          function restore(state){
+            for (let i=0; i<N; i++){
+              pos[i] = state.pos[i];
+              used[i] = state.used[i];
+              cipherOwner[i] = state.cipherOwner[i];
+              const destDom = letterDomains[i];
+              const srcDom = state.letterDomains[i];
+              for (let v=0; v<N; v++) destDom[v] = srcDom[v];
+            }
+            for (let r=0; r<mLen; r++){
+              keyInit[r] = state.keyInit[r];
+              keyDomainSizes[r] = state.keyDomainSizes[r];
+              const destDom = keyDomains[r];
+              const srcDom = state.keyDomains[r];
+              for (let v=0; v<N; v++) destDom[v] = srcDom[v];
+            }
+            for (let L=0; L<N; L++){
+              letterDomainSizes[L] = state.letterDomainSizes[L];
+            }
+          }
+
+          function finalizeSolution(){
+            const posFull = pos.slice();
+            const usedValues = new Array(N).fill(false);
+            for (let L=0; L<N; L++){
+              const v = posFull[L];
+              if (v !== null) usedValues[v] = true;
+            }
+            const remaining = [];
+            for (let v=0; v<N; v++) if (!usedValues[v]) remaining.push(v);
+            for (let L=0; L<N; L++){
+              if (posFull[L] === null){
+                const next = remaining.length ? remaining.shift() : 0;
+                posFull[L] = next;
+              }
+            }
+            const keyFull = keyInit.slice();
+            for (let r=0; r<mLen; r++) keyFull[r] = mod(keyFull[r] == null ? 0 : keyFull[r]);
+            return { pos: posFull, k: keyFull };
+          }
+
+          function stateKey(){
+            let out = '';
+            for (let L=0; L<N; L++) out += pos[L] === null ? '_' : pos[L].toString(36);
+            out += '|';
+            for (let r=0; r<mLen; r++) out += keyInit[r] === null ? '_' : keyInit[r].toString(36);
+            return out;
+          }
+
+          const memo = new Set();
+          let dfsNodes = 0;
+          let lastPing = typeof performance !== 'undefined' ? performance.now() : 0;
+
           function dfs(){
-            if (__cancelled) return null;
             if (!propagate()) return null;
+            if (isSolved()) return finalizeSolution();
+            const memoKey = stateKey();
+            if (memo.has(memoKey)) return null;
             const sel = chooseVar();
-            if (!sel){
-              const posFull = pos.slice();
-              const free = [];
-              for (let v=0; v<N; v++){ if (!used[v]) free.push(v); }
-              for (let L=0; L<N; L++){ if (posFull[L]===null) posFull[L] = free.shift(); }
-              const keyFull = keyInit.slice().map(x => x===null ? 0 : mod(x));
-              return { pos: posFull, k: keyFull };
+            if (!sel) return finalizeSolution();
+            dfsNodes++;
+            if (progressCb && dfsNodes % 500 === 0){
+              const now = typeof performance !== 'undefined' ? performance.now() : 0;
+              if (!lastPing || now - lastPing > 120){
+                lastPing = now;
+                progressCb({ kind:'dfs', nodes: dfsNodes });
+              }
             }
             if (sel.type === 'letter'){
-              const candSet = new Set();
-              for (const cons of constraints){
-                if (cons.pSym === sel.idx){
-                  if (cons.type === 'init'){
-                    const b = pos[cons.cSym];
-                    const keyVal = keyInit[cons.idx];
-                    if (b !== null && keyVal !== null) candSet.add(mod(b - keyVal));
-                  } else {
-                    const b = pos[cons.cSym];
-                    const dep = pos[cons.depSym];
-                    if (b !== null && dep !== null) candSet.add(mod(b - dep));
-                  }
-                }
-                if (cons.cSym === sel.idx){
-                  if (cons.type === 'init'){
-                    const a = pos[cons.pSym];
-                    const keyVal = keyInit[cons.idx];
-                    if (a !== null && keyVal !== null) candSet.add(mod(a + keyVal));
-                  } else {
-                    const a = pos[cons.pSym];
-                    const dep = pos[cons.depSym];
-                    if (a !== null && dep !== null) candSet.add(mod(a + dep));
-                  }
-                }
-                if (cons.type === 'feed' && cons.depSym === sel.idx){
-                  const a = pos[cons.pSym];
-                  const b = pos[cons.cSym];
-                  if (b !== null && a !== null) candSet.add(mod(b - a));
-                }
-              }
-              const free = [];
-              for (let v=0; v<N; v++){ if (!used[v]) free.push(v); }
-              const candidates = candSet.size ? Array.from(candSet).filter(v => !used[v]) : free;
-              for (const val of candidates){
-                if (__cancelled) return null;
+              const domain = letterDomainValues(sel.idx);
+              domain.sort((a,b)=>a-b);
+              for (const val of domain){
                 const snap = snapshot();
-                const vv = mod(val);
-                pos[sel.idx] = vv;
-                used[vv] = true;
-                const res = dfs();
-                if (res) return res;
+                const res = assignLetter(sel.idx, val, null);
+                if (!res.ok){ restore(snap); continue; }
+                const out = dfs();
+                if (out) return out;
                 restore(snap);
               }
             } else {
-              const candSet = new Set();
-              for (const cons of constraints){
-                if (cons.type === 'init' && cons.idx === sel.idx){
-                  const a = pos[cons.pSym];
-                  const b = pos[cons.cSym];
-                  if (a !== null && b !== null) candSet.add(mod(b - a));
-                }
-              }
-              const candidates = candSet.size ? Array.from(candSet) : [...Array(N).keys()];
-              for (const val of candidates){
-                if (__cancelled) return null;
+              const domain = keyDomainValues(sel.idx);
+              domain.sort((a,b)=>a-b);
+              for (const val of domain){
                 const snap = snapshot();
-                keyInit[sel.idx] = mod(val);
-                const res = dfs();
-                if (res) return res;
+                const res = assignKey(sel.idx, val, null);
+                if (!res.ok){ restore(snap); continue; }
+                const out = dfs();
+                if (out) return out;
                 restore(snap);
               }
             }
+            memo.add(memoKey);
             return null;
           }
 
-          return dfs();
+          if (propagateOnly){
+            if (!propagate()) return false;
+            if (isSolved()) return true;
+            if (MAX_TRIALS <= 0 || TRIAL_DEPTH <= 0) return false;
+            const baseline = snapshot();
+            for (let t=0; t<MAX_TRIALS; t++){
+              restore(baseline);
+              let success = true;
+              for (let depth=0; depth<TRIAL_DEPTH; depth++){
+                const sel = chooseVar();
+                if (!sel) break;
+                const domain = sel.type === 'letter' ? letterDomainValues(sel.idx) : keyDomainValues(sel.idx);
+                if (!domain.length){ success = false; break; }
+                const tries = Math.min(3, domain.length);
+                let progressed = false;
+                for (let i=0; i<tries; i++){
+                  const val = domain[(t + depth + i) % domain.length];
+                  const snap = snapshot();
+                  const res = sel.type === 'letter' ? assignLetter(sel.idx, val, null) : assignKey(sel.idx, val, null);
+                  if (!res.ok){ restore(snap); continue; }
+                  if (!propagate()){ restore(snap); continue; }
+                  progressed = true;
+                  break;
+                }
+                if (!progressed){ success = false; break; }
+              }
+              if (success){
+                if (isSolved()) return true;
+                if (propagate()) return true;
+              }
+            }
+            return false;
+          }
+
+          const sol = dfs();
+          if (!sol) return null;
+          return sol;
         }
+
         function decryptAutokeyUnknownAlphabet(letters, pos, keyInit){
           const N = 26;
           const inv = new Array(N); for (let L=0; L<N; L++) inv[pos[L]] = String.fromCharCode(65+L);
@@ -2425,6 +3220,7 @@ try{
           const stepToAbs = new Array(cLetters.length).fill(-1);
           for (let i=0; i<absToLetterStep.length; i++){ const step = absToLetterStep[i]; if (step >= 0) stepToAbs[step] = i; }
           const existingCribs = collectContiguousCribs(letters, cribMap);
+          const baseAssignments = buildAutokeyStepAssignments(letters, cribMap);
           const selLen = selectionLength > 0 ? selectionLength : (endPos - startPos + 1);
           const cipherSeg = cLetters.slice(startPos, endPos + 1).join('');
           const totalWords = wordlist.length;
@@ -2473,42 +3269,93 @@ try{
                 }
               }
               if (!conflict){
+                let assignmentsForWord = null;
+                if (op === 'autokey_custom_alpha'){
+                  assignmentsForWord = extendAutokeyAssignments(baseAssignments, letters, word, startPos, stepToAbs);
+                  if (!assignmentsForWord || assignmentsForWord.conflict){
+                    continue;
+                  }
+                }
+                const baseStateCache = new Map();
+                const getBaseState = (kk) => {
+                  if (op !== 'autokey_custom_alpha') return null;
+                  if (!assignmentsForWord) return null;
+                  if (baseStateCache.has(kk)) return baseStateCache.get(kk);
+                  const baseState = prepareAutokeyBaseState(assignmentsForWord, kk);
+                  if (baseState) baseStateCache.set(kk, baseState);
+                  return baseState;
+                };
                 const plausible = [];
                 for (let kk=minKVal; kk<=maxKVal && !__cancelled; kk++){
                   try {
-                    const quick = (op === 'vig_custom_alpha')
-                      ? solveVigUnknownAlphabet(letters, candidateCribMap, kk, quickOpts)
-                      : solveAutokeyUnknownAlphabet(letters, candidateCribMap, kk, quickOpts);
-                    if (quick){
-                      plausible.push(kk);
+                    if (op === 'vig_custom_alpha'){
+                      const quick = solveVigUnknownAlphabet(letters, candidateCribMap, kk, quickOpts);
+                      if (quick){
+                        plausible.push(kk);
+                      }
+                    } else {
+                      const baseState = getBaseState(kk);
+                      if (!baseState) continue;
+                      const quick = solveAutokeyUnknownAlphabet(
+                        letters,
+                        candidateCribMap,
+                        kk,
+                        Object.assign({}, quickOpts, { baseState })
+                      );
+                      if (quick){
+                        plausible.push(kk);
+                      }
                     }
                   } catch(e){}
                 }
-                if (!plausible.length) continue;
+                if (!plausible.length){
+                  if (shouldReport(idx)){
+                    postMessage({ kind:'brute_progress', done: idx+1, total: progressTotal, checked:wordsChecked, skipped:wordsSkipped });
+                  }
+                  continue;
+                }
                 for (const kk of plausible){
                   if (__cancelled) break;
                   try {
-                    const sol = (op === 'vig_custom_alpha')
-                      ? solveVigUnknownAlphabet(letters, candidateCribMap, kk)
-                      : solveAutokeyUnknownAlphabet(letters, candidateCribMap, kk);
-                    if (!sol || !sol.pos || !sol.k) continue;
-                    const fullDec = (op === 'vig_custom_alpha')
-                      ? decryptWithCustomAlphabet(letters, sol.pos, sol.k)
-                      : decryptAutokeyUnknownAlphabet(letters, sol.pos, sol.k);
-                    if (enforceNext && nextSegmentLen > 0 && !matchesNextSegment(fullDec, nextSegment)) continue;
-                    const decLetters = sanitize(fullDec).split('');
-                    const fitness = englishFitness(decLetters);
-                    const inv = new Array(26);
-                    for (let L=0; L<26; L++){ inv[sol.pos[L]] = A[L]; }
-                    results.push({
-                      word,
-                      keyLength: kk,
-                      key: sol.k.map(x=>A[x]).join(''),
-                      alphabet: inv.join(''),
-                      decrypted: fullDec,
-                      fitness,
-                      op
-                    });
+                    if (op === 'vig_custom_alpha'){
+                      const sol = solveVigUnknownAlphabet(letters, candidateCribMap, kk);
+                      if (!sol || !sol.pos || !sol.k) continue;
+                      const fullDec = decryptWithCustomAlphabet(letters, sol.pos, sol.k);
+                      if (enforceNext && nextSegmentLen > 0 && !matchesNextSegment(fullDec, nextSegment)) continue;
+                      const decLetters = sanitize(fullDec).split('');
+                      const fitness = englishFitness(decLetters);
+                      const inv = new Array(26);
+                      for (let L=0; L<26; L++){ inv[sol.pos[L]] = A[L]; }
+                      results.push({
+                        word,
+                        keyLength: kk,
+                        key: sol.k.map(x=>A[x]).join(''),
+                        alphabet: inv.join(''),
+                        decrypted: fullDec,
+                        fitness,
+                        op
+                      });
+                    } else {
+                      const baseState = getBaseState(kk);
+                      if (!baseState) continue;
+                      const sol = solveAutokeyUnknownAlphabet(letters, candidateCribMap, kk, { baseState });
+                      if (!sol || !sol.pos || !sol.k) continue;
+                      const fullDec = decryptAutokeyUnknownAlphabet(letters, sol.pos, sol.k);
+                      if (enforceNext && nextSegmentLen > 0 && !matchesNextSegment(fullDec, nextSegment)) continue;
+                      const decLetters = sanitize(fullDec).split('');
+                      const fitness = englishFitness(decLetters);
+                      const inv = new Array(26);
+                      for (let L=0; L<26; L++){ inv[sol.pos[L]] = A[L]; }
+                      results.push({
+                        word,
+                        keyLength: kk,
+                        key: sol.k.map(x=>A[x]).join(''),
+                        alphabet: inv.join(''),
+                        decrypted: fullDec,
+                        fitness,
+                        op
+                      });
+                    }
                   } catch(e){}
                 }
               }


### PR DESCRIPTION
## Summary
- add reusable autokey constraint helpers so brute-force runs can share precomputed base state
- rewrite the autokey unknown-alphabet solver with stronger propagation, domain pruning, and memoized DFS backtracking
- update the web worker brute-force loop to cache assignments per word and reuse prepared solver state across quick and full solves

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5b605e90883319e7eb3bcdfab8b5a