### PR TITLE
Add Beaufort variants to autokey mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,12 @@
         <option value="vig_custom_alpha">Vigenère with unknown alphabet (shared custom order)</option>
         <option value="autokey_custom_alpha">Autokey with unknown alphabet (shared custom order)</option>
       </select>
+      <label id="autokeyAlgoLabel" class="small muted" style="display:none">Autokey variant:</label>
+      <select id="autokeyAlgo" style="display:none">
+        <option value="vigenere">Vigenère-style (C = P + K)</option>
+        <option value="beaufort">Beaufort (C = K − P)</option>
+        <option value="beaufort_variant">Variant Beaufort (C = P − K)</option>
+      </select>
       <button id="render">Render grid</button>
       <button id="test">Test cribs</button>
       <button id="stopSearch" style="display:none">Stop search</button>
@@ -179,6 +185,40 @@ function englishFitness(upArr){
   const subs = wordHits(s);
   const raw = chi + 4*subs;
   return (raw / n) * 100;
+}
+
+const AUTOKEY_ALGOS = ['vigenere','beaufort','beaufort_variant'];
+function normalizeAutokeyAlgo(value){
+  if (value === 'beaufort' || value === 'beaufort_variant') return value;
+  return 'vigenere';
+}
+function autokeyAlgoLabel(algo){
+  const norm = normalizeAutokeyAlgo(algo);
+  if (norm === 'beaufort') return 'Beaufort';
+  if (norm === 'beaufort_variant') return 'Variant Beaufort';
+  return 'Vigenère-style';
+}
+function autokeyOpsFor(algo){
+  const norm = normalizeAutokeyAlgo(algo);
+  if (norm === 'beaufort'){
+    return {
+      keyFromPlainCipher: (p, c) => c + p,
+      cipherFromPlainKey: (p, k) => k - p,
+      plainFromCipherKey: (c, k) => k - c
+    };
+  }
+  if (norm === 'beaufort_variant'){
+    return {
+      keyFromPlainCipher: (p, c) => p - c,
+      cipherFromPlainKey: (p, k) => p - k,
+      plainFromCipherKey: (c, k) => c + k
+    };
+  }
+  return {
+    keyFromPlainCipher: (p, c) => c - p,
+    cipherFromPlainKey: (p, k) => p + k,
+    plainFromCipherKey: (c, k) => c - k
+  };
 }
 
 // ===== Selection mode =====
@@ -659,6 +699,7 @@ function solveCipherSubDeterministic(cLetters, constraints, minK, maxK){
 function testCribs(){
   const {letters, cribMap} = gatherCribs();
   const op = document.getElementById('op').value;
+  const selectedAutokeyAlgo = op === 'autokey_custom_alpha' ? currentAutokeyAlgo() : null;
   const segments = collectContiguousCribs(letters, cribMap);
   const minK = parseInt(document.getElementById('minK').value);
   const maxK = parseInt(document.getElementById('maxK').value);
@@ -832,7 +873,7 @@ function bruteForceWordlist(){
   const wrongLengthSkipped = wordlist.length - filtered.length;
 
   if (filtered.length === 0){
-    displayBruteResults([], startPos, endPos, 0, wrongLengthSkipped, 0, maxResults, { bridgeNext, nextSegmentLen, timedOutWords: 0 });
+    displayBruteResults([], startPos, endPos, 0, wrongLengthSkipped, 0, maxResults, { bridgeNext, nextSegmentLen, timedOutWords: 0, autokeyAlgo: selectedAutokeyAlgo });
     return;
   }
 
@@ -854,6 +895,7 @@ function bruteForceWordlist(){
     minK,
     maxK,
     op,
+    autokeyAlgo: currentAutokeyAlgo(),
     maxResults,
     quickTrials,
     trialDepth,
@@ -874,6 +916,7 @@ function displayBruteResults(results, startPos, endPos, wordsChecked, wordsSkipp
   const bridgeNext = !!opts.bridgeNext;
   const nextSegmentLen = (typeof opts.nextSegmentLen === 'number') ? opts.nextSegmentLen : undefined;
   const timedOutWords = (typeof opts.timedOutWords === 'number') ? opts.timedOutWords : 0;
+  const variantLabel = opts.autokeyAlgo ? autokeyAlgoLabel(opts.autokeyAlgo) : null;
   const panel = document.getElementById('bruteResults');
   const summary = document.getElementById('bruteSummary');
   const out = document.getElementById('bruteOut');
@@ -884,6 +927,9 @@ function displayBruteResults(results, startPos, endPos, wordsChecked, wordsSkipp
   const limit = (typeof maxResults === 'number' && !Number.isNaN(maxResults)) ? maxResults : shown;
   const timeoutText = timedOutWords > 0 ? `, timed out ${timedOutWords}` : '';
   let text = `Found ${total} consistent cribs at positions ${startPos}-${endPos}. Showing top ${shown} (limit ${limit}). Checked ${wordsChecked} words (skipped ${wordsSkipped} wrong-length words${timeoutText}). Sorted by decryption quality.`;
+  if (variantLabel){
+    text += ` Autokey variant: ${variantLabel}.`;
+  }
   if (bridgeNext){
     if (nextSegmentLen === undefined){
       text += ' Enforcing next crib segment (length pending).';
@@ -899,9 +945,10 @@ function displayBruteResults(results, startPos, endPos, wordsChecked, wordsSkipp
   results.forEach((r, idx) => {
     const div = document.createElement('div');
     div.className = idx < 5 ? 'result-item top' : 'result-item';
-    
+
     const wordSpan = document.createElement('div');
-    wordSpan.innerHTML = `<strong>Word:</strong> ${r.word} | <strong>Key Length:</strong> ${r.keyLength} | <strong>Key:</strong> ${r.key} | <span class="score">Score: ${r.fitness.toFixed(2)}</span>`;
+    const variantInfo = r.autokeyAlgo ? ` | <strong>Variant:</strong> ${autokeyAlgoLabel(r.autokeyAlgo)}` : '';
+    wordSpan.innerHTML = `<strong>Word:</strong> ${r.word} | <strong>Key Length:</strong> ${r.keyLength} | <strong>Key:</strong> ${r.key}${variantInfo} | <span class="score">Score: ${r.fitness.toFixed(2)}</span>`;
     
     const decSpan = document.createElement('pre');
     decSpan.textContent = r.decrypted;
@@ -1270,7 +1317,7 @@ function solveVigUnknownAlphabet(letters, cribMap, m, options){
 
 
 
-function solveAutokeyUnknownAlphabet(letters, cribMap, m, options){
+function solveAutokeyUnknownAlphabet(letters, cribMap, m, options, algo){
   const opts = (options && typeof options === 'object') ? options : null;
   if (opts){
     opts.timedOut = false;
@@ -1347,6 +1394,11 @@ function solveAutokeyUnknownAlphabet(letters, cribMap, m, options){
   const keyInit = new Array(m).fill(null);
 
   const mod = (x)=>((x%N)+N)%N;
+  const algorithm = normalizeAutokeyAlgo(algo);
+  const ops = autokeyOpsFor(algorithm);
+  const keyFromPlainCipher = (p, c) => mod(ops.keyFromPlainCipher(p, c));
+  const cipherFromPlainKey = (p, k) => mod(ops.cipherFromPlainKey(p, k));
+  const plainFromCipherKey = (c, k) => mod(ops.plainFromCipherKey(c, k));
 
   function assignLetter(idx, value){
     if (idx == null) return {ok:true, changed:false};
@@ -1381,17 +1433,17 @@ function solveAutokeyUnknownAlphabet(letters, cribMap, m, options){
           const b = pos[cons.cSym];
           const keyVal = keyInit[cons.idx];
           if (a !== null && b !== null){
-            const res = assignKey(cons.idx, b - a);
+            const res = assignKey(cons.idx, keyFromPlainCipher(a, b));
             if (!res.ok) return false;
             if (res.changed) changed = true;
           }
           if (a !== null && keyVal !== null){
-            const res = assignLetter(cons.cSym, a + keyVal);
+            const res = assignLetter(cons.cSym, cipherFromPlainKey(a, keyVal));
             if (!res.ok) return false;
             if (res.changed) changed = true;
           }
           if (b !== null && keyVal !== null){
-            const res = assignLetter(cons.pSym, b - keyVal);
+            const res = assignLetter(cons.pSym, plainFromCipherKey(b, keyVal));
             if (!res.ok) return false;
             if (res.changed) changed = true;
           }
@@ -1400,7 +1452,7 @@ function solveAutokeyUnknownAlphabet(letters, cribMap, m, options){
           const b = pos[cons.cSym];
           const dep = pos[cons.depSym];
           if (a !== null && dep !== null){
-            const res = assignLetter(cons.cSym, a + dep);
+            const res = assignLetter(cons.cSym, cipherFromPlainKey(a, dep));
             if (!res.ok) return false;
             if (res.changed) changed = true;
           }
@@ -1408,12 +1460,12 @@ function solveAutokeyUnknownAlphabet(letters, cribMap, m, options){
           const aNow = pos[cons.pSym];
           const depNow = pos[cons.depSym];
           if (bNow !== null && aNow !== null){
-            const res = assignLetter(cons.depSym, bNow - aNow);
+            const res = assignLetter(cons.depSym, keyFromPlainCipher(aNow, bNow));
             if (!res.ok) return false;
             if (res.changed) changed = true;
           }
           if (bNow !== null && depNow !== null){
-            const res = assignLetter(cons.pSym, bNow - depNow);
+            const res = assignLetter(cons.pSym, plainFromCipherKey(bNow, depNow));
             if (!res.ok) return false;
             if (res.changed) changed = true;
           }
@@ -1474,28 +1526,28 @@ function solveAutokeyUnknownAlphabet(letters, cribMap, m, options){
           if (cons.type === 'init'){
             const b = pos[cons.cSym];
             const keyVal = keyInit[cons.idx];
-            if (b !== null && keyVal !== null) candSet.add(mod(b - keyVal));
+            if (b !== null && keyVal !== null) candSet.add(plainFromCipherKey(b, keyVal));
           } else {
             const b = pos[cons.cSym];
             const dep = pos[cons.depSym];
-            if (b !== null && dep !== null) candSet.add(mod(b - dep));
+            if (b !== null && dep !== null) candSet.add(plainFromCipherKey(b, dep));
           }
         }
         if (cons.cSym === sel.idx){
           if (cons.type === 'init'){
             const a = pos[cons.pSym];
             const keyVal = keyInit[cons.idx];
-            if (a !== null && keyVal !== null) candSet.add(mod(a + keyVal));
+            if (a !== null && keyVal !== null) candSet.add(cipherFromPlainKey(a, keyVal));
           } else {
             const a = pos[cons.pSym];
             const dep = pos[cons.depSym];
-            if (a !== null && dep !== null) candSet.add(mod(a + dep));
+            if (a !== null && dep !== null) candSet.add(cipherFromPlainKey(a, dep));
           }
         }
         if (cons.type === 'feed' && cons.depSym === sel.idx){
           const a = pos[cons.pSym];
           const b = pos[cons.cSym];
-          if (b !== null && a !== null) candSet.add(mod(b - a));
+          if (b !== null && a !== null) candSet.add(keyFromPlainCipher(a, b));
         }
       }
       const free = [];
@@ -1517,7 +1569,7 @@ function solveAutokeyUnknownAlphabet(letters, cribMap, m, options){
         if (cons.type === 'init' && cons.idx === sel.idx){
           const a = pos[cons.pSym];
           const b = pos[cons.cSym];
-          if (a !== null && b !== null) candSet.add(mod(b - a));
+          if (a !== null && b !== null) candSet.add(keyFromPlainCipher(a, b));
         }
       }
       const candidates = candSet.size ? Array.from(candSet) : [...Array(N).keys()];
@@ -1561,12 +1613,16 @@ function decryptWithCustomAlphabet(letters, pos, k){
   return out;
 }
 
-function decryptAutokeyUnknownAlphabet(letters, pos, keyInit){
+function decryptAutokeyUnknownAlphabet(letters, pos, keyInit, algo){
   const N = 26;
   const inv = new Array(N); for (let L=0; L<N; L++) inv[pos[L]] = A[L];
   const plainPositions = [];
   let step = 0;
   let out = '';
+  const mod = (x)=>((x%N)+N)%N;
+  const algorithm = normalizeAutokeyAlgo(algo);
+  const ops = autokeyOpsFor(algorithm);
+  const plainFromCipherKey = (c, k) => mod(ops.plainFromCipherKey(c, k));
   for (let i=0; i<letters.length; i++){
     const ch = letters[i];
     if (!isLetter(ch)){ out += ch; continue; }
@@ -1578,8 +1634,8 @@ function decryptAutokeyUnknownAlphabet(letters, pos, keyInit){
       keyVal = plainPositions[step - keyInit.length];
     }
     if (keyVal == null) keyVal = 0;
-    keyVal = ((keyVal % N) + N) % N;
-    const pIdx = ((cIdx - keyVal) % N + N) % N;
+    keyVal = mod(keyVal);
+    const pIdx = plainFromCipherKey(cIdx, keyVal);
     plainPositions.push(pIdx);
     out += inv[pIdx];
     step++;
@@ -1666,7 +1722,9 @@ async function runUnknownAlphabetInline(){
   if (segments.length === 0){ summary.textContent='Enter at least one crib segment.'; return; }
   const total = (maxK - minK + 1);
   const isVigMode = (op === 'vig_custom_alpha');
-  showProgress(total, isVigMode ? 'Unknown alphabet Vigenère' : 'Autokey + unknown alphabet');
+  const autokeyAlgo = currentAutokeyAlgo();
+  const autokeyLabel = autokeyAlgoLabel(autokeyAlgo);
+  showProgress(total, isVigMode ? 'Unknown alphabet Vigenère' : `Autokey (${autokeyLabel}) + unknown alphabet`);
   const results=[];
   const coveragePerM = [];
   for (let kLen=minK; kLen<=maxK; kLen++){
@@ -1677,11 +1735,11 @@ async function runUnknownAlphabetInline(){
     }
     const sol = isVigMode
       ? solveVigUnknownAlphabet(letters, cribMap, kLen)
-      : solveAutokeyUnknownAlphabet(letters, cribMap, kLen);
+      : solveAutokeyUnknownAlphabet(letters, cribMap, kLen, undefined, autokeyAlgo);
     if (sol){
       const dec = isVigMode
         ? decryptWithCustomAlphabet(letters, sol.pos, sol.k)
-        : decryptAutokeyUnknownAlphabet(letters, sol.pos, sol.k);
+        : decryptAutokeyUnknownAlphabet(letters, sol.pos, sol.k, autokeyAlgo);
       const fitness = englishFitness( sanitize(dec).split('') );
       results.push({ keyLength:kLen, key: sol.k.map(x=>A[x]).join(''), preview: dec.slice(0,160), score: fitness, posRaw: sol.pos, kRaw: sol.k });
     }
@@ -1725,7 +1783,7 @@ async function runUnknownAlphabetInline(){
       const pre = document.createElement('pre'); pre.className='small muted'; pre.textContent = debugLines.join('\n');
       out.appendChild(pre);
     } else {
-      summary.textContent = `No solution for key lengths ${minK}..${maxK} under autokey + unknown alphabet.`;
+      summary.textContent = `No solution for key lengths ${minK}..${maxK} under autokey + unknown alphabet (${autokeyLabel}).`;
       const pre = document.createElement('pre'); pre.className='small muted';
       const detailLines = [];
       for (const {m, coverage} of coveragePerM){
@@ -1765,7 +1823,7 @@ try{
       const alphaStr = inv.join('');
       const fullText = isVigMode
         ? decryptWithCustomAlphabet(letters, best.posRaw, best.kRaw)
-        : decryptAutokeyUnknownAlphabet(letters, best.posRaw, best.kRaw);
+        : decryptAutokeyUnknownAlphabet(letters, best.posRaw, best.kRaw, autokeyAlgo);
       const fullBlock = document.createElement('pre');
       fullBlock.textContent =
         `Best candidate (m=${best.keyLength})\n` +
@@ -1779,7 +1837,7 @@ try{
 
   summary.textContent = isVigMode
     ? `Found ${results.length} solution(s) for unknown alphabet Vigenère.`
-    : `Found ${results.length} solution(s) for autokey + unknown alphabet.`;
+    : `Found ${results.length} solution(s) for autokey + unknown alphabet (${autokeyLabel}).`;
   results.slice(0,50).forEach((r,idx)=>{
     const div=document.createElement('div'); div.className='row';
     const head=document.createElement('div'); head.textContent = `#${idx+1}  m=${r.keyLength}  initialKey=${r.key}`;
@@ -1803,6 +1861,8 @@ try{
     const BTN_TEST = $("test");
     const BTN_STOP = $("stopSearch");
     const SEL_OP   = $("op");
+    const SEL_AUTOKEY_ALGO = $("autokeyAlgo");
+    const LBL_AUTOKEY_ALGO = $("autokeyAlgoLabel");
     const OUT      = $("out");
     const SUMMARY  = $("summary");
     const CAND_CNT = $("uaCandidatesCount");
@@ -1814,6 +1874,21 @@ try{
     let uaWorker = null;
     let currentJob = null;
     let bruteCtx = null;
+
+    function currentAutokeyAlgo(){
+      return normalizeAutokeyAlgo(SEL_AUTOKEY_ALGO ? SEL_AUTOKEY_ALGO.value : 'vigenere');
+    }
+
+    function updateAutokeyAlgoVisibility(){
+      if (!SEL_AUTOKEY_ALGO) return;
+      const op = SEL_OP ? SEL_OP.value : '';
+      const show = op === 'autokey_custom_alpha';
+      SEL_AUTOKEY_ALGO.style.display = show ? '' : 'none';
+      if (LBL_AUTOKEY_ALGO) LBL_AUTOKEY_ALGO.style.display = show ? '' : 'none';
+      if (!show && SEL_AUTOKEY_ALGO){
+        SEL_AUTOKEY_ALGO.value = normalizeAutokeyAlgo(SEL_AUTOKEY_ALGO.value);
+      }
+    }
 
     function gatherForWorker(){
       const letters = ($("ctext") ? $("ctext").value : "").split("");
@@ -1831,7 +1906,7 @@ try{
       const minK = $("minK") ? parseInt($("minK").value) : 2;
       const maxK = $("maxK") ? parseInt($("maxK").value) : 20;
       const op = SEL_OP ? SEL_OP.value : '';
-      return { letters, cribPairs, minK, maxK, op };
+      return { letters, cribPairs, minK, maxK, op, autokeyAlgo: currentAutokeyAlgo() };
     }
 
     function makeWorker(){
@@ -1882,6 +1957,33 @@ try{
           const cnt={}; for (const ch of upArr){ cnt[ch]=(cnt[ch]||0)+1; }
           let chi=0; for (const ch of A){ const obs=(cnt[ch]||0); const exp=FREQ[ch]*n/100; if (exp>0) chi += (obs-exp)*(obs-exp)/exp; }
           return -chi;
+        }
+        const AUTOKEY_ALGOS = ['vigenere','beaufort','beaufort_variant'];
+        function normalizeAutokeyAlgo(value){
+          if (value === 'beaufort' || value === 'beaufort_variant') return value;
+          return 'vigenere';
+        }
+        function autokeyOpsFor(algo){
+          const norm = normalizeAutokeyAlgo(algo);
+          if (norm === 'beaufort'){
+            return {
+              keyFromPlainCipher: (p, c) => c + p,
+              cipherFromPlainKey: (p, k) => k - p,
+              plainFromCipherKey: (c, k) => k - c
+            };
+          }
+          if (norm === 'beaufort_variant'){
+            return {
+              keyFromPlainCipher: (p, c) => p - c,
+              cipherFromPlainKey: (p, k) => p - k,
+              plainFromCipherKey: (c, k) => c + k
+            };
+          }
+          return {
+            keyFromPlainCipher: (p, c) => c - p,
+            cipherFromPlainKey: (p, k) => p + k,
+            plainFromCipherKey: (c, k) => c - k
+          };
         }
         function solveVigUnknownAlphabet(letters, cribMap, m, progressCb){
           const N=26;
@@ -2035,8 +2137,35 @@ try{
           }
           return out;
         }
-        function solveAutokeyUnknownAlphabet(letters, cribMap, m){
+        function solveAutokeyUnknownAlphabet(letters, cribMap, m, options, algo){
+          const opts = (options && typeof options === 'object') ? options : null;
+          if (opts){
+            opts.timedOut = false;
+            opts.visitedNodes = 0;
+          }
           const N = 26;
+          let timedOut = false;
+          let nodeVisits = 0;
+          const maxMillis = (opts && Number.isFinite(opts.maxMillis) && opts.maxMillis > 0) ? opts.maxMillis : null;
+          const maxNodes = (opts && Number.isFinite(opts.maxNodes) && opts.maxNodes > 0) ? opts.maxNodes|0 : null;
+          const timeFn = (typeof performance !== 'undefined' && typeof performance.now === 'function')
+            ? () => performance.now()
+            : () => Date.now();
+          const hasTimeLimit = maxMillis !== null;
+          const startTime = hasTimeLimit ? timeFn() : 0;
+          function limitReached(){
+            if (__cancelled) return true;
+            if (timedOut) return true;
+            if (hasTimeLimit && (timeFn() - startTime) >= maxMillis){
+              timedOut = true;
+              return true;
+            }
+            if (maxNodes !== null && nodeVisits >= maxNodes){
+              timedOut = true;
+              return true;
+            }
+            return false;
+          }
           if (!Number.isFinite(m) || m <= 0) return null;
           const segments = collectContiguousCribs(letters, cribMap);
           if (!segments.length) return null;
@@ -2057,7 +2186,7 @@ try{
             }
           }
           if (!stepPlain.size) return null;
-
+        
           const constraints = [];
           const letterDeg = new Array(N).fill(0);
           const keyDeg = new Array(m).fill(0);
@@ -2080,12 +2209,18 @@ try{
             letterDeg[cSym]++;
           }
           if (!constraints.length) return null;
-
+        
           const pos = new Array(N).fill(null);
           const used = new Array(N).fill(false);
           const keyInit = new Array(m).fill(null);
+        
           const mod = (x)=>((x%N)+N)%N;
-
+          const algorithm = normalizeAutokeyAlgo(algo);
+          const ops = autokeyOpsFor(algorithm);
+          const keyFromPlainCipher = (p, c) => mod(ops.keyFromPlainCipher(p, c));
+          const cipherFromPlainKey = (p, k) => mod(ops.cipherFromPlainKey(p, k));
+          const plainFromCipherKey = (c, k) => mod(ops.plainFromCipherKey(c, k));
+        
           function assignLetter(idx, value){
             if (idx == null) return {ok:true, changed:false};
             value = mod(value);
@@ -2097,7 +2232,7 @@ try{
             }
             return {ok: pos[idx] === value, changed:false};
           }
-
+        
           function assignKey(idx, value){
             value = mod(value);
             if (keyInit[idx] === null){
@@ -2106,28 +2241,30 @@ try{
             }
             return {ok: keyInit[idx] === value, changed:false};
           }
-
+        
           function propagate(){
             let changed = true;
             while (changed){
+              if (limitReached()) return false;
               changed = false;
               for (const cons of constraints){
+                if (limitReached()) return false;
                 if (cons.type === 'init'){
                   const a = pos[cons.pSym];
                   const b = pos[cons.cSym];
                   const keyVal = keyInit[cons.idx];
                   if (a !== null && b !== null){
-                    const res = assignKey(cons.idx, b - a);
+                    const res = assignKey(cons.idx, keyFromPlainCipher(a, b));
                     if (!res.ok) return false;
                     if (res.changed) changed = true;
                   }
                   if (a !== null && keyVal !== null){
-                    const res = assignLetter(cons.cSym, a + keyVal);
+                    const res = assignLetter(cons.cSym, cipherFromPlainKey(a, keyVal));
                     if (!res.ok) return false;
                     if (res.changed) changed = true;
                   }
                   if (b !== null && keyVal !== null){
-                    const res = assignLetter(cons.pSym, b - keyVal);
+                    const res = assignLetter(cons.pSym, plainFromCipherKey(b, keyVal));
                     if (!res.ok) return false;
                     if (res.changed) changed = true;
                   }
@@ -2136,7 +2273,7 @@ try{
                   const b = pos[cons.cSym];
                   const dep = pos[cons.depSym];
                   if (a !== null && dep !== null){
-                    const res = assignLetter(cons.cSym, a + dep);
+                    const res = assignLetter(cons.cSym, cipherFromPlainKey(a, dep));
                     if (!res.ok) return false;
                     if (res.changed) changed = true;
                   }
@@ -2144,21 +2281,22 @@ try{
                   const aNow = pos[cons.pSym];
                   const depNow = pos[cons.depSym];
                   if (bNow !== null && aNow !== null){
-                    const res = assignLetter(cons.depSym, bNow - aNow);
+                    const res = assignLetter(cons.depSym, keyFromPlainCipher(aNow, bNow));
                     if (!res.ok) return false;
                     if (res.changed) changed = true;
                   }
                   if (bNow !== null && depNow !== null){
-                    const res = assignLetter(cons.pSym, bNow - depNow);
+                    const res = assignLetter(cons.pSym, plainFromCipherKey(bNow, depNow));
                     if (!res.ok) return false;
                     if (res.changed) changed = true;
                   }
                 }
               }
             }
+            if (limitReached()) return false;
             return true;
           }
-
+        
           function chooseVar(){
             let bestLetter=-1, bestScore=-1;
             for (let L=0; L<N; L++){
@@ -2178,7 +2316,7 @@ try{
             if (bestKey !== -1 && bestKeyScore>0) return {type:'key', idx:bestKey};
             return null;
           }
-
+        
           function snapshot(){
             return { pos: pos.slice(), used: used.slice(), key: keyInit.slice() };
           }
@@ -2186,10 +2324,13 @@ try{
             for (let i=0;i<N;i++){ pos[i]=state.pos[i]; used[i]=state.used[i]; }
             for (let i=0;i<m;i++){ keyInit[i]=state.key[i]; }
           }
-
+        
           function dfs(){
-            if (__cancelled) return null;
+            if (limitReached()) return null;
+            nodeVisits++;
+            if (limitReached()) return null;
             if (!propagate()) return null;
+            if (limitReached()) return null;
             const sel = chooseVar();
             if (!sel){
               const posFull = pos.slice();
@@ -2206,41 +2347,41 @@ try{
                   if (cons.type === 'init'){
                     const b = pos[cons.cSym];
                     const keyVal = keyInit[cons.idx];
-                    if (b !== null && keyVal !== null) candSet.add(mod(b - keyVal));
+                    if (b !== null && keyVal !== null) candSet.add(plainFromCipherKey(b, keyVal));
                   } else {
                     const b = pos[cons.cSym];
                     const dep = pos[cons.depSym];
-                    if (b !== null && dep !== null) candSet.add(mod(b - dep));
+                    if (b !== null && dep !== null) candSet.add(plainFromCipherKey(b, dep));
                   }
                 }
                 if (cons.cSym === sel.idx){
                   if (cons.type === 'init'){
                     const a = pos[cons.pSym];
                     const keyVal = keyInit[cons.idx];
-                    if (a !== null && keyVal !== null) candSet.add(mod(a + keyVal));
+                    if (a !== null && keyVal !== null) candSet.add(cipherFromPlainKey(a, keyVal));
                   } else {
                     const a = pos[cons.pSym];
                     const dep = pos[cons.depSym];
-                    if (a !== null && dep !== null) candSet.add(mod(a + dep));
+                    if (a !== null && dep !== null) candSet.add(cipherFromPlainKey(a, dep));
                   }
                 }
                 if (cons.type === 'feed' && cons.depSym === sel.idx){
                   const a = pos[cons.pSym];
                   const b = pos[cons.cSym];
-                  if (b !== null && a !== null) candSet.add(mod(b - a));
+                  if (b !== null && a !== null) candSet.add(keyFromPlainCipher(a, b));
                 }
               }
               const free = [];
               for (let v=0; v<N; v++){ if (!used[v]) free.push(v); }
               const candidates = candSet.size ? Array.from(candSet).filter(v => !used[v]) : free;
               for (const val of candidates){
-                if (__cancelled) return null;
                 const snap = snapshot();
                 const vv = mod(val);
                 pos[sel.idx] = vv;
                 used[vv] = true;
                 const res = dfs();
                 if (res) return res;
+                if (timedOut) return null;
                 restore(snap);
               }
             } else {
@@ -2249,30 +2390,43 @@ try{
                 if (cons.type === 'init' && cons.idx === sel.idx){
                   const a = pos[cons.pSym];
                   const b = pos[cons.cSym];
-                  if (a !== null && b !== null) candSet.add(mod(b - a));
+                  if (a !== null && b !== null) candSet.add(keyFromPlainCipher(a, b));
                 }
               }
               const candidates = candSet.size ? Array.from(candSet) : [...Array(N).keys()];
               for (const val of candidates){
-                if (__cancelled) return null;
                 const snap = snapshot();
                 keyInit[sel.idx] = mod(val);
                 const res = dfs();
                 if (res) return res;
+                if (timedOut) return null;
                 restore(snap);
               }
             }
             return null;
           }
-
-          return dfs();
+        
+          if (options && options.propagateOnly){
+            return propagate();
+          }
+        
+          const solved = dfs();
+          if (opts){
+            opts.timedOut = timedOut;
+            opts.visitedNodes = nodeVisits;
+          }
+          return solved;
         }
-        function decryptAutokeyUnknownAlphabet(letters, pos, keyInit){
+        function decryptAutokeyUnknownAlphabet(letters, pos, keyInit, algo){
           const N = 26;
           const inv = new Array(N); for (let L=0; L<N; L++) inv[pos[L]] = String.fromCharCode(65+L);
           const plainPositions = [];
           let step = 0;
           let out = '';
+          const mod = (x)=>((x%N)+N)%N;
+          const algorithm = normalizeAutokeyAlgo(algo);
+          const ops = autokeyOpsFor(algorithm);
+          const plainFromCipherKey = (c, k) => mod(ops.plainFromCipherKey(c, k));
           for (let i=0; i<letters.length; i++){
             const ch = letters[i];
             if (!isLetter(ch)){ out += ch; continue; }
@@ -2284,8 +2438,8 @@ try{
               keyVal = plainPositions[step - keyInit.length];
             }
             if (keyVal == null) keyVal = 0;
-            keyVal = ((keyVal % N) + N) % N;
-            const pIdx = ((cIdx - keyVal) % N + N) % N;
+            keyVal = mod(keyVal);
+            const pIdx = plainFromCipherKey(cIdx, keyVal);
             plainPositions.push(pIdx);
             out += inv[pIdx];
             step++;
@@ -2460,6 +2614,7 @@ try{
           const minK = msg.minK|0;
           const maxK = msg.maxK|0;
           const op = msg.op || 'vigenere';
+          const autokeyAlgo = op === 'autokey_custom_alpha' ? normalizeAutokeyAlgo(msg.autokeyAlgo) : null;
           const maxResults = msg.maxResults|0;
           const quickTrials = Number.isFinite(msg.quickTrials) ? Math.max(0, msg.quickTrials|0) : 30;
           const trialDepth = Number.isFinite(msg.trialDepth) ? Math.max(0, msg.trialDepth|0) : 3;
@@ -2573,7 +2728,7 @@ try{
                       } else if (perWordTimeoutMs > 0){
                         quickOptions.maxMillis = perWordTimeoutMs;
                       }
-                      const quick = solveAutokeyUnknownAlphabet(letters, candidateCribMap, kk, quickOptions);
+                      const quick = solveAutokeyUnknownAlphabet(letters, candidateCribMap, kk, quickOptions, autokeyAlgo);
                       if (quickOptions && quickOptions.timedOut){
                         wordTimedOut = true;
                         break;
@@ -2621,13 +2776,13 @@ try{
                           const remaining = Math.max(1, Math.floor(remainingRaw));
                           solveOpts.maxMillis = remaining;
                         }
-                        const sol = solveAutokeyUnknownAlphabet(letters, candidateCribMap, kk, solveOpts);
+                        const sol = solveAutokeyUnknownAlphabet(letters, candidateCribMap, kk, solveOpts, autokeyAlgo);
                         if (solveOpts && solveOpts.timedOut){
                           wordTimedOut = true;
                           break;
                         }
                         if (!sol || !sol.pos || !sol.k) continue;
-                        const fullDec = decryptAutokeyUnknownAlphabet(letters, sol.pos, sol.k);
+                        const fullDec = decryptAutokeyUnknownAlphabet(letters, sol.pos, sol.k, autokeyAlgo);
                         if (enforceNext && nextSegmentLen > 0 && !matchesNextSegment(fullDec, nextSegment)) continue;
                         const decLetters = sanitize(fullDec).split('');
                         const fitness = englishFitness(decLetters);
@@ -2640,7 +2795,8 @@ try{
                           alphabet: inv.join(''),
                           decrypted: fullDec,
                           fitness,
-                          op: 'autokey_custom_alpha'
+                          op: 'autokey_custom_alpha',
+                          autokeyAlgo: autokeyAlgo
                         });
                       }
                     } catch(e){}
@@ -2761,7 +2917,7 @@ try{
           }
           results.sort((a,b)=> (isFinite(b.fitness)?b.fitness:-Infinity) - (isFinite(a.fitness)?a.fitness:-Infinity));
           const limited = (maxResults && maxResults > 0) ? results.slice(0, maxResults) : results.slice();
-          postMessage({ kind:'brute_done', results: limited, totalCandidates: results.length, wordsChecked, wordsSkipped, startPos, endPos, maxResults, cancelled: __cancelled, bridgeNext: enforceNext, nextSegmentLen, wordsTimedOut });
+          postMessage({ kind:'brute_done', results: limited, totalCandidates: results.length, wordsChecked, wordsSkipped, startPos, endPos, maxResults, cancelled: __cancelled, bridgeNext: enforceNext, nextSegmentLen, wordsTimedOut, autokeyAlgo });
         }
         onmessage = (ev)=>{
           const msg = ev.data||{};
@@ -2781,17 +2937,18 @@ try{
             const letters = msg.letters || [];
             const cribMap = {}; for (const pair of (msg.cribPairs||[])){ if (pair && pair.length >= 2) cribMap[pair[0]] = pair[1]; }
             const minK = msg.minK|0, maxK = msg.maxK|0;
+            const autokeyAlgo = normalizeAutokeyAlgo(msg.autokeyAlgo);
             const total = Math.max(1, maxK - minK + 1);
             postMessage({ kind:'progress', done:0, total, label:'m='+minK, candidatesFound: __candsFound });
             const results=[];
             for (let m=minK; m<=maxK && !__cancelled; m++){
               if (op === 'autokey_custom_alpha'){
-                const sol = solveAutokeyUnknownAlphabet(letters, cribMap, m);
+                const sol = solveAutokeyUnknownAlphabet(letters, cribMap, m, undefined, autokeyAlgo);
                 if (sol){
-                  const dec = decryptAutokeyUnknownAlphabet(letters, sol.pos, sol.k);
+                  const dec = decryptAutokeyUnknownAlphabet(letters, sol.pos, sol.k, autokeyAlgo);
                   const fit = englishFitness(dec.toUpperCase().replace(/[^A-Z]/g,'').split(''));
                   __candsFound++;
-                  const cand = { keyLength:m, key: sol.k.map(v=>String.fromCharCode(65+v)).join(''), posRaw: sol.pos, kRaw: sol.k, score: fit, preview: dec.slice(0,200), full: dec };
+                  const cand = { keyLength:m, key: sol.k.map(v=>String.fromCharCode(65+v)).join(''), posRaw: sol.pos, kRaw: sol.k, score: fit, preview: dec.slice(0,200), full: dec, autokeyAlgo };
                   results.push(cand);
                   postMessage({ kind:'candidate', ...cand });
                 }
@@ -2810,7 +2967,7 @@ try{
               postMessage({ kind:'done', cancelled:true, results });
             } else {
               results.sort((a,b)=>b.score-a.score);
-              postMessage({kind:'done', op, results});
+              postMessage({kind:'done', op, results, autokeyAlgo });
             }
           }
         };
@@ -2826,6 +2983,7 @@ try{
     }
 
     function updateStopVisibility(){
+      updateAutokeyAlgoVisibility();
       if (!BTN_STOP) return;
       if (currentJob){
         BTN_STOP.style.display = 'inline-block';
@@ -2867,7 +3025,9 @@ try{
         return;
       }
       const isAutokey = payload.op === 'autokey_custom_alpha';
-      const modeLabel = isAutokey ? 'autokey + unknown alphabet' : 'unknown alphabet Vigenère';
+      const modeLabel = isAutokey
+        ? `autokey (${autokeyAlgoLabel(payload.autokeyAlgo)}) + unknown alphabet`
+        : 'unknown alphabet Vigenère';
 
       currentJob = 'unknown';
       bruteCtx = null;
@@ -2978,9 +3138,11 @@ try{
             for (let L=0; L<26; L++){ inv[best.posRaw[L]] = String.fromCharCode(65+L); }
             const alphaStr = inv.join('');
             const block = document.createElement('pre');
+            const variantLine = isAutokey ? `variant:    ${autokeyAlgoLabel(payload.autokeyAlgo)}\n` : '';
             block.textContent =
               `Best candidate (m=${best.keyLength})\n` +
               `${isAutokey ? 'initial key: ' : 'key residues: '}${best.key}\n` +
+              variantLine +
               `alphabet:    ${alphaStr}\n\n` +
               (best.full || '');
             target.appendChild(block);
@@ -3035,7 +3197,8 @@ try{
         maxResults: payload.maxResults,
         skippedPre,
         totalWords,
-        bridgeNext: !!payload.bridgeNext
+        bridgeNext: !!payload.bridgeNext,
+        autokeyAlgo: payload.op === 'autokey_custom_alpha' ? normalizeAutokeyAlgo(payload.autokeyAlgo) : null
       };
 
       if (BTN_BRUTE) BTN_BRUTE.disabled = true;
@@ -3049,6 +3212,10 @@ try{
         let text = `Running brute force on ${totalWords.toLocaleString()} word(s) (skipped ${skippedPre.toLocaleString()} wrong-length).`;
         if (payload.bridgeNext){
           text += ' Enforcing next crib segment.';
+        }
+        if (payload.op === 'autokey_custom_alpha'){
+          const variantLabel = autokeyAlgoLabel(normalizeAutokeyAlgo(payload.autokeyAlgo));
+          text += ` Autokey variant: ${variantLabel}.`;
         }
         BRUTE_SUMMARY.textContent = text;
       }
@@ -3082,6 +3249,9 @@ try{
             if (bruteCtx && bruteCtx.bridgeNext){
               text += ' Enforcing next crib segment.';
             }
+            if (bruteCtx && bruteCtx.autokeyAlgo){
+              text += ` Autokey variant: ${autokeyAlgoLabel(bruteCtx.autokeyAlgo)}.`;
+            }
             BRUTE_SUMMARY.textContent = text;
           }
           return;
@@ -3109,7 +3279,7 @@ try{
             wordsSkipped,
             totalCandidates,
             data.maxResults,
-            { bridgeNext: !!data.bridgeNext, nextSegmentLen: typeof data.nextSegmentLen === 'number' ? data.nextSegmentLen : undefined, timedOutWords: typeof data.wordsTimedOut === 'number' ? data.wordsTimedOut|0 : 0 }
+            { bridgeNext: !!data.bridgeNext, nextSegmentLen: typeof data.nextSegmentLen === 'number' ? data.nextSegmentLen : undefined, timedOutWords: typeof data.wordsTimedOut === 'number' ? data.wordsTimedOut|0 : 0, autokeyAlgo: data.autokeyAlgo }
           );
           if (data.cancelled && BRUTE_SUMMARY){
             BRUTE_SUMMARY.textContent += ' (stopped early)';
@@ -3150,10 +3320,13 @@ try{
     }
 
     if (SEL_OP){
-      SEL_OP.addEventListener('change', updateStopVisibility);
+      SEL_OP.addEventListener('change', () => {
+        updateStopVisibility();
+      });
       updateStopVisibility();
     } else {
       resetStop();
+      updateAutokeyAlgoVisibility();
     }
 
     if (typeof window !== 'undefined'){

--- a/index.html
+++ b/index.html
@@ -198,6 +198,10 @@ function autokeyAlgoLabel(algo){
   if (norm === 'beaufort_variant') return 'Variant Beaufort';
   return 'Vigenère-style';
 }
+function currentAutokeyAlgo(){
+  const sel = document.getElementById('autokeyAlgo');
+  return normalizeAutokeyAlgo(sel ? sel.value : 'vigenere');
+}
 function autokeyOpsFor(algo){
   const norm = normalizeAutokeyAlgo(algo);
   if (norm === 'beaufort'){
@@ -1874,10 +1878,6 @@ try{
     let uaWorker = null;
     let currentJob = null;
     let bruteCtx = null;
-
-    function currentAutokeyAlgo(){
-      return normalizeAutokeyAlgo(SEL_AUTOKEY_ALGO ? SEL_AUTOKEY_ALGO.value : 'vigenere');
-    }
 
     function updateAutokeyAlgoVisibility(){
       if (!SEL_AUTOKEY_ALGO) return;


### PR DESCRIPTION
## Summary
- add an autokey variant selector so users can choose Vigenère, Beaufort, or variant Beaufort decoding
- extend the unknown-alphabet autokey solver/decryptor (main thread and worker) to honour the selected variant
- propagate the variant through inline testing and brute-force tooling, including result summaries

## Testing
- Not run (web project)

------
https://chatgpt.com/codex/tasks/task_e_68e6a704a98483319b7eb6f344a82e2b