### PR TITLE
Overhaul autokey puzzle UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -2466,6 +2466,27 @@ try{
     let currentJob = null;
     let bruteCtx = null;
 
+    const AUTO_STOP_MS = 15000;
+    const AUTO_STOP_MESSAGE = "Hmm… I need a little more information to confirm this one — try adding more crib letters and test again!";
+    let autoStopTimer = null;
+
+    function clearAutoStopTimer(){
+      if (autoStopTimer){
+        clearTimeout(autoStopTimer);
+        autoStopTimer = null;
+      }
+    }
+
+    function scheduleAutoStop(){
+      clearAutoStopTimer();
+      autoStopTimer = setTimeout(() => {
+        stopWorker(AUTO_STOP_MESSAGE, '');
+        if (SUMMARY){
+          setSummaryMessage(AUTO_STOP_MESSAGE, { noResult: true });
+        }
+      }, AUTO_STOP_MS);
+    }
+
     function updateAutokeyAlgoVisibility(){
       if (!SEL_AUTOKEY_ALGO) return;
       const op = SEL_OP ? SEL_OP.value : '';
@@ -3616,6 +3637,7 @@ try{
     }
 
     function stopWorker(summaryText, outText){
+      clearAutoStopTimer();
       if (uaWorker){
         try { uaWorker.postMessage({cmd:'cancel'}); } catch(e){}
         try { uaWorker.terminate(); } catch(e){}
@@ -3662,6 +3684,7 @@ try{
       if (OUT) OUT.textContent = '';
       if (CAND_CNT) CAND_CNT.textContent = '0';
       showProgress(1);
+      scheduleAutoStop();
 
       if (uaWorker){ try { uaWorker.terminate(); } catch(e){} }
       uaWorker = makeWorker();
@@ -3708,6 +3731,7 @@ try{
           return;
         }
         if (kind === 'result' || kind === 'done'){
+          clearAutoStopTimer();
           hideProgress();
           if (BTN_STOP){
             BTN_STOP.disabled = true;

--- a/index.html
+++ b/index.html
@@ -8,15 +8,15 @@
 #progressBar{background:#f97316;height:100%;width:0%;transition:width .3s ease}
 
     :root{
-      --bg:#f3f4ff;
-      --panel:#ffffff;
-      --muted:#5b6780;
-      --ink:#131728;
-      --accent:#6366f1;
-      --accent-soft:rgba(99,102,241,0.15);
-      --input-bg:#f4f5ff;
-      --input-ink:#131728;
-      --input-bd:#d7dcf9;
+      --bg:#020617;
+      --panel:#0f172a;
+      --muted:#94a3b8;
+      --ink:#f8fafc;
+      --accent:#38bdf8;
+      --accent-soft:rgba(56,189,248,0.18);
+      --input-bg:#0b1220;
+      --input-ink:#f8fafc;
+      --input-bd:#1e293b;
       --hot:#f97316;
       --cold:#38bdf8;
       font-family:'Nunito', 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
@@ -24,7 +24,7 @@
     body {
       margin: 0;
       min-height: 100vh;
-      background: radial-gradient(circle at top left, #eef1ff, #f3f4ff 55%, #e8edff 100%);
+      background: radial-gradient(circle at top left, #172554 0%, #020617 55%, #01030f 100%);
       color: var(--ink);
       padding: 32px 18px 54px;
       box-sizing: border-box;
@@ -52,7 +52,7 @@
     .panel {
       background: var(--panel);
       border-radius: 18px;
-      box-shadow: 0 20px 45px rgba(15,23,42,0.08);
+      box-shadow: 0 28px 60px rgba(2,6,23,0.55);
       padding: 24px;
       position: relative;
       overflow: hidden;
@@ -77,14 +77,14 @@
       border-radius:14px;
       background:var(--input-bg);
       color:var(--input-ink);
-      border:2px solid transparent;
+      border:2px solid var(--input-bd);
       transition:border-color .2s ease, box-shadow .2s ease;
-      box-shadow:0 6px 18px rgba(99,102,241,0.08);
+      box-shadow:0 12px 26px rgba(8,17,35,0.65);
     }
     textarea:focus {
       outline:none;
       border-color:var(--accent);
-      box-shadow:0 12px 30px rgba(99,102,241,0.16);
+      box-shadow:0 14px 34px rgba(56,189,248,0.35);
     }
     .grid {
       display:flex;
@@ -93,7 +93,8 @@
       margin-top:16px;
       padding:18px;
       border-radius:16px;
-      background:linear-gradient(145deg, rgba(99,102,241,0.08), rgba(56,189,248,0.08));
+      background:linear-gradient(145deg, rgba(56,189,248,0.08), rgba(15,118,110,0.08));
+      border:1px solid rgba(148,163,184,0.12);
     }
     .cell {
       width:38px;
@@ -107,14 +108,14 @@
     .char {
       display:block;
       padding:8px 0;
-      background:#ffffff;
+      background:#1e293b;
       border-radius:12px;
       font-weight:700;
       border:2px solid transparent;
       width:100%;
       box-sizing:border-box;
       color:var(--accent);
-      box-shadow:0 6px 15px rgba(148,163,184,0.28);
+      box-shadow:0 10px 22px rgba(2,6,23,0.55);
     }
     .cell.selecting { cursor:pointer }
     .cell.selected .char { border-color:var(--accent); }
@@ -123,18 +124,18 @@
       text-align:center;
       border-radius:12px;
       padding:10px 0;
-      background:#fff;
+      background:#1e293b;
       color:var(--input-ink);
-      border:2px solid rgba(99,102,241,0.25);
+      border:2px solid rgba(56,189,248,0.35);
       font-weight:800;
       box-sizing:border-box;
       font-size:20px;
       min-height:44px;
       transition:border-color .2s ease, box-shadow .2s ease;
-      box-shadow:0 6px 15px rgba(99,102,241,0.08);
+      box-shadow:0 10px 24px rgba(8,17,35,0.55);
     }
-    input.cribin:focus { outline:none; border-color:var(--accent); box-shadow:0 12px 30px rgba(99,102,241,0.16); }
-    input.cribin[disabled]{ opacity:.35; cursor:not-allowed; background:rgba(255,255,255,0.7); box-shadow:none }
+    input.cribin:focus { outline:none; border-color:var(--accent); box-shadow:0 16px 36px rgba(56,189,248,0.38); }
+    input.cribin[disabled]{ opacity:.35; cursor:not-allowed; background:rgba(15,23,42,0.9); box-shadow:none }
     .controls {
       display:flex;
       gap:12px;
@@ -151,19 +152,20 @@
       cursor:pointer;
       transition:transform .15s ease, box-shadow .2s ease;
       background:var(--accent);
-      color:#fff;
-      box-shadow:0 14px 30px rgba(99,102,241,0.28);
+      color:#05132c;
+      box-shadow:0 18px 34px rgba(56,189,248,0.28);
     }
     .controls button.secondary {
-      background:rgba(99,102,241,0.1);
-      color:var(--accent);
-      box-shadow:none;
+      background:rgba(15,23,42,0.9);
+      color:var(--muted);
+      box-shadow:0 12px 28px rgba(2,6,23,0.55);
+      border:1px solid rgba(148,163,184,0.18);
     }
-    .controls button:hover { transform:translateY(-1px); box-shadow:0 18px 36px rgba(99,102,241,0.28); }
-    .controls button.secondary:hover { box-shadow:0 8px 20px rgba(99,102,241,0.2); }
+    .controls button:hover { transform:translateY(-1px); box-shadow:0 22px 40px rgba(56,189,248,0.35); }
+    .controls button.secondary:hover { box-shadow:0 16px 30px rgba(2,6,23,0.7); }
     button:disabled { opacity:.45; cursor:not-allowed; box-shadow:none; transform:none }
     pre {
-      background:rgba(99,102,241,0.07);
+      background:rgba(15,23,42,0.85);
       padding:18px;
       border-radius:16px;
       overflow:auto;
@@ -171,7 +173,7 @@
       font-size:16px;
       line-height:1.6;
       color:var(--ink);
-      box-shadow:inset 0 0 0 1px rgba(99,102,241,0.12);
+      box-shadow:inset 0 0 0 1px rgba(56,189,248,0.12);
     }
     .muted { color:var(--muted); }
     .legend { display:none }
@@ -180,18 +182,19 @@
     .heat-track {
       position:relative;
       height:20px;
-      background:linear-gradient(90deg,var(--cold),#38c0f8,#60a5fa,#a855f7,var(--hot));
+      background:rgba(15,23,42,0.9);
+      border:1px solid rgba(56,189,248,0.25);
       border-radius:999px;
       overflow:hidden;
-      box-shadow:0 6px 14px rgba(99,102,241,0.18);
+      box-shadow:0 14px 30px rgba(2,6,23,0.65);
     }
     .heat-fill {
       position:absolute;
       top:0;left:0;height:100%;
       width:0%;
-      background:rgba(255,255,255,0.65);
-      mix-blend-mode:overlay;
-      transition:width .35s ease;
+      background:linear-gradient(90deg,var(--cold) 0%, #60a5fa 25%, #a855f7 60%, var(--hot) 100%);
+      box-shadow:0 0 18px rgba(249,115,22,0.45);
+      transition:width .35s ease, box-shadow .35s ease;
     }
     .heat-labels {
       margin-top:6px;
@@ -207,21 +210,23 @@
       margin-top:14px;
     }
     .chip {
-      background:rgba(99,102,241,0.12);
-      color:var(--accent);
+      background:rgba(8,17,35,0.85);
+      color:var(--muted);
       padding:8px 14px;
       border-radius:999px;
       font-weight:700;
       font-size:13px;
+      border:1px solid rgba(56,189,248,0.18);
     }
     .hidden-control { display:none !important; }
     #progressWrap {
       display:none;
       margin-top:14px;
-      background:rgba(99,102,241,0.1);
+      background:rgba(15,23,42,0.9);
       border-radius:999px;
       height:18px;
       overflow:hidden;
+      border:1px solid rgba(56,189,248,0.2);
     }
     #progressLabel { margin-top:8px; font-weight:600; color:var(--muted); }
     #progressInner { height:100%; background:linear-gradient(90deg, var(--cold), var(--accent)); width:0%; transition:width .3s ease; }
@@ -284,7 +289,7 @@
       <div id="summary" class="small muted">No test run yet — add a few guesses to start!</div>
       <div class="heat-meter">
         <div class="heat-track">
-          <div id="heatFill" class="heat-fill"></div>
+          <div id="heatFill" class="heat-fill" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
         </div>
         <div class="heat-labels"><span>Cold</span><span>Hot!</span></div>
       </div>
@@ -337,6 +342,13 @@ const isLetter = ch => /[A-Za-z]/.test(ch);
 const sanitize = s => s.toUpperCase().replace(/[^A-Z]/g,'');
 
 let wordlist = [];
+
+const NO_RESULT_MESSAGES = [
+  "That wasn't it! The cipher sprites are asking for another guess.",
+  "Mystery still locked — add a few fresh crib letters and try again!",
+  "Close, but the parchment stays secret. Shuffle your guesses and rerun the test.",
+  "The heat meter stayed frosty. Give the puzzle a different sprinkle of clues."
+];
 
 function getQuickTrials(){
   const el = document.getElementById('quickTrialsInput');
@@ -415,20 +427,26 @@ function computeEnglishStats(text){
   return { chi, ic, length: n, clean };
 }
 
+function clamp01(x){
+  if (!Number.isFinite(x)) return 0;
+  return Math.max(0, Math.min(1, x));
+}
+
 function scoreHeat(stats){
   if (!stats || !stats.length){
     return { score: 0, chi: stats ? stats.chi : 0, ic: stats ? stats.ic : 0, length: stats ? stats.length : 0 };
   }
-  const CHI_TARGET = 33;
-  const CHI_SPREAD = 60;
-  const IOC_TARGET = 0.0667;
-  const IOC_SPREAD = 0.02;
-  const chiDelta = Math.abs((stats.chi || 0) - CHI_TARGET);
-  const chiScore = Math.max(0, 1 - (chiDelta / CHI_SPREAD));
-  const iocDelta = Math.abs((stats.ic || 0) - IOC_TARGET);
-  const iocScore = Math.max(0, 1 - (iocDelta / IOC_SPREAD));
-  const score = Math.max(0, Math.min(1, (chiScore * 0.6) + (iocScore * 0.4)));
-  return { score, chi: stats.chi, ic: stats.ic, length: stats.length };
+  const chi = Math.max(0, stats.chi || 0);
+  const ic = stats.ic || 0;
+  const chiComponent = clamp01(1 / (1 + chi / 55));
+  const iocTarget = 0.0667;
+  const iocSpread = 0.015;
+  const iocComponent = clamp01(Math.exp(-Math.abs(ic - iocTarget) / iocSpread));
+  const lengthConfidence = clamp01((stats.length || 0) / 120);
+  const base = (chiComponent * 0.55) + (iocComponent * 0.45);
+  const boosted = base * (0.45 + (0.55 * lengthConfidence));
+  const score = clamp01(boosted);
+  return { score, chi: chi, ic, length: stats.length };
 }
 
 function updateHeatMeter(stats){
@@ -441,6 +459,10 @@ function updateHeatMeter(stats){
   if (!stats || !stats.length){
     heatFill.style.width = '0%';
     heatFill.style.opacity = '0.35';
+    heatFill.style.boxShadow = 'none';
+    heatFill.setAttribute('aria-valuenow', '0');
+    heatFill.setAttribute('aria-valuemin', '0');
+    heatFill.setAttribute('aria-valuemax', '100');
     chiStat.textContent = 'χ²: —';
     iocStat.textContent = 'IOC: —';
     return { score: 0, chi: 0, ic: 0 };
@@ -449,6 +471,12 @@ function updateHeatMeter(stats){
   const pct = Math.round(scored.score * 100);
   heatFill.style.width = `${pct}%`;
   heatFill.style.opacity = '1';
+  const glow = Math.max(12, 12 + pct * 0.2);
+  const glowAlpha = Math.min(0.75, 0.25 + pct / 200);
+  heatFill.style.boxShadow = pct > 0 ? `0 0 ${glow}px rgba(249,115,22,${glowAlpha.toFixed(2)})` : 'none';
+  heatFill.setAttribute('aria-valuenow', String(pct));
+  heatFill.setAttribute('aria-valuemin', '0');
+  heatFill.setAttribute('aria-valuemax', '100');
   const chiVal = scored.chi.toFixed(2);
   const iocVal = scored.ic.toFixed(4);
   chiStat.textContent = `χ²: ${chiVal}`;
@@ -3474,32 +3502,12 @@ try{
 
           const baseResults = Array.isArray(data.results) && data.results.length ? data.results : streamed;
           if (!baseResults.length){
-            if (SUMMARY) SUMMARY.textContent = `No solution for key lengths ${payload.minK}..${payload.maxK} under ${modeLabel}.`;
-            if (isAutokey && OUT){
-              const letters = Array.isArray(payload.letters) ? payload.letters : [];
-              const cribMap = {};
-              (Array.isArray(payload.cribPairs) ? payload.cribPairs : []).forEach(([pos, letter]) => {
-                if (typeof pos === 'number' && letter){ cribMap[pos] = letter; }
-              });
-              const detailLines = [];
-              for (let m = payload.minK; m <= payload.maxK; m++){
-                const cov = autokeyCoverageDiagnostics(letters, cribMap, m);
-                if (!cov) continue;
-                const residues = (cov.residues || []).map((cnt, idx)=>`${idx}:${cnt}`).join(', ');
-                detailLines.push(`m=${m}: crib steps=${cov.totalSteps}, feed links=${cov.feedLinks}, missing feed=${cov.missingFeed.length}, residues {${residues}}`);
-                if (cov.missingFeed.length){
-                  const sample = cov.missingFeed.slice(0,5).map(({step, dependsOn})=>`(${step}<-${dependsOn})`).join(' ');
-                  if (sample){
-                    detailLines.push(`  uncovered autokey links: ${sample}${cov.missingFeed.length>5?' …':''}`);
-                  }
-                }
-              }
-              if (detailLines.length){
-                OUT.textContent = detailLines.join('\n');
-              } else {
-                OUT.textContent = 'Autokey mode relies on chained crib coverage (positions spaced by the key length). Try adding overlapping cribs or narrowing the key-length range.';
-              }
+            if (SUMMARY){
+              const idx = Math.floor(Math.random() * NO_RESULT_MESSAGES.length);
+              SUMMARY.textContent = NO_RESULT_MESSAGES[idx] || 'No luck this time — give it another whirl!';
             }
+            if (OUT) OUT.textContent = '';
+            updateHeatMeter(null);
             return;
           }
           baseResults.sort((a,b)=> (b.score||0) - (a.score||0));
@@ -3517,11 +3525,13 @@ try{
           const scored = updateHeatMeter(stats);
           if (SUMMARY){
             const pct = Math.round((scored.score || 0) * 100);
-            let mood = 'Chilly — try adding more crib letters to warm it up.';
-            if (pct >= 75) mood = 'Hot! This looks a lot like natural English.';
-            else if (pct >= 45) mood = 'Warm — you are closing in on a readable solution.';
-            else if (pct === 0) mood = 'We need more clues before the heat meter can move.';
-            SUMMARY.textContent = `Key length ${best.keyLength}: ${mood}`;
+            let mood;
+            if (pct >= 90) mood = '🔥 Blazing! That reads like a solved mystery.';
+            else if (pct >= 65) mood = '🌶️ Spicy! The plaintext is almost unlocked.';
+            else if (pct >= 40) mood = '✨ Warming up — a few tweaks might crack it.';
+            else if (pct > 0) mood = '🧊 Still chilly. Try sprinkling in more crib letters.';
+            else mood = 'Add a few more confident letters so the meter can take a proper reading.';
+            SUMMARY.textContent = `Key length ${best.keyLength}: ${mood} (${pct}% hot)`;
           }
         }
       };

--- a/index.html
+++ b/index.html
@@ -19,12 +19,18 @@
       --cold:#38bdf8;
       font-family:'Nunito', 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
     }
+    *, *::before, *::after { box-sizing:border-box; }
     .thinking-panel {
       display:flex;
       align-items:center;
       justify-content:center;
       text-align:center;
-      min-height:110px;
+      min-height:96px;
+      background:rgba(8,17,35,0.85);
+      border-radius:18px;
+      border:1px solid rgba(56,189,248,0.14);
+      box-shadow:inset 0 0 0 1px rgba(15,23,42,0.4);
+      padding:18px;
     }
     .thinking-text {
       font-size:22px;
@@ -39,7 +45,7 @@
       min-height: 100vh;
       background: radial-gradient(circle at top left, #172554 0%, #020617 55%, #01030f 100%);
       color: var(--ink);
-      padding: 32px 18px 54px;
+      padding: 32px 18px 280px;
       box-sizing: border-box;
       display: flex;
       flex-direction: column;
@@ -84,6 +90,31 @@
       opacity:.4;
       pointer-events:none;
     }
+    .floating-panel {
+      position:fixed;
+      left:50%;
+      transform:translateX(-50%);
+      bottom:calc(32px + env(safe-area-inset-bottom, 0px));
+      width:min(520px, calc(100% - 40px));
+      background:rgba(15,23,42,0.95);
+      border-radius:22px;
+      box-shadow:0 38px 80px rgba(2,6,23,0.75), 0 0 0 1px rgba(56,189,248,0.12);
+      padding:26px 28px 28px;
+      display:flex;
+      flex-direction:column;
+      gap:18px;
+      z-index:40;
+      backdrop-filter:blur(12px);
+    }
+    #results {
+      max-height:min(420px, 70vh);
+      overflow-y:auto;
+    }
+    #out {
+      max-height:220px;
+      overflow:auto;
+      margin-top:6px;
+    }
     textarea {
       width:100%;
       min-height:120px;
@@ -112,6 +143,7 @@
       background:linear-gradient(145deg, rgba(56,189,248,0.08), rgba(15,118,110,0.08));
       border:1px solid rgba(148,163,184,0.12);
       align-items:flex-start;
+      overflow-x:auto;
     }
     .word {
       display:flex;
@@ -265,7 +297,7 @@
       border:1px solid rgba(56,189,248,0.18);
     }
     .hidden-control { display:none !important; }
-    #progressPanel { display:none; }
+    #progressPanel { display:none; width:100%; }
     #progressLabel { font-weight:800; font-size:22px; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); text-shadow:0 0 26px rgba(56,189,248,0.35); }
 
     .confetti-container {
@@ -291,35 +323,42 @@
       100% { opacity:0; transform:translate3d(var(--confetti-x, 0px), 120vh, 0) rotate(360deg); }
     }
     @media (max-width: 720px) {
-      body { padding:24px 16px; }
+      body { padding:24px 16px 340px; }
       .hero { width:100%; }
       .panel { padding:20px; }
       .grid { justify-content:center; }
       .cell { width:44px; }
       textarea { min-height:140px; }
+      .floating-panel {
+        width:calc(100% - 24px);
+        bottom:calc(20px + env(safe-area-inset-bottom, 0px));
+        padding:22px 22px 24px;
+        border-radius:20px;
+      }
+      #results { max-height:65vh; }
     }
 
     @media (max-width: 480px) {
       .controls { justify-content:center; }
       .controls button { flex:1 1 100%; max-width:280px; }
       textarea { min-height:160px; }
+      .floating-panel { bottom:calc(18px + env(safe-area-inset-bottom, 0px)); }
     }
 
     @media (min-width: 1100px) {
-      body { padding:48px 48px 72px; }
+      body { padding:48px 48px 320px; }
       .hero { width:min(1100px, 100%); }
       .panels {
         display:grid;
         grid-template-columns:repeat(12, minmax(0, 1fr));
         gap:22px;
         grid-template-areas:
-          "setup setup setup setup results results results results results results results results"
+          "setup setup setup setup setup setup setup setup setup setup setup setup"
           "grid grid grid grid grid grid grid grid grid grid grid grid"
           "wordlist wordlist wordlist wordlist wordlist wordlist wordlist wordlist wordlist wordlist wordlist wordlist"
           "brute brute brute brute brute brute brute brute brute brute brute brute";
       }
       #setupPanel { grid-area: setup; }
-      #results { grid-area: results; }
       #gridPanel { grid-area: grid; }
       #wordlistPanel { grid-area: wordlist; }
       #bruteResults { grid-area: brute; }
@@ -371,7 +410,7 @@
       <div id="grid" class="grid"></div>
     </section>
 
-    <section class="panel" id="results">
+    <section class="floating-panel" id="results">
       <h2>Step 3 · See how hot your guess is</h2>
       <div id="summary" class="summary-text muted">No test run yet — add a few guesses to start!</div>
       <div class="heat-meter">
@@ -1549,7 +1588,7 @@ function ensureProgressPanel(){
   const after = document.getElementById('out');
   panel = document.createElement('div');
   panel.id = 'progressPanel';
-  panel.className = 'panel thinking-panel';
+  panel.className = 'thinking-panel';
   const lab = document.createElement('div');
   lab.id = 'progressLabel';
   lab.className = 'thinking-text';

--- a/index.html
+++ b/index.html
@@ -3756,11 +3756,6 @@ try{
         if (SUMMARY) setSummaryMessage('Enter at least one crib segment first.');
         return;
       }
-      const isAutokey = payload.op === 'autokey_custom_alpha';
-      const modeLabel = isAutokey
-        ? `autokey (${autokeyAlgoLabel(payload.autokeyAlgo)}) + unknown alphabet`
-        : 'unknown alphabet Vigenère';
-
       currentJob = 'unknown';
       bruteCtx = null;
 
@@ -3769,110 +3764,189 @@ try{
         BTN_STOP.disabled = false;
       }
       updateStopVisibility();
-      if (SUMMARY) setSummaryMessage(`Running ${modeLabel}…`);
       if (OUT) OUT.textContent = '';
       if (CAND_CNT) CAND_CNT.textContent = '0';
-      showProgress(1);
+      updateHeatMeter(null);
       scheduleAutoStop();
 
-      if (uaWorker){ try { uaWorker.terminate(); } catch(e){} }
-      uaWorker = makeWorker();
-
-      const streamed = [];
+      const queue = AUTOKEY_ALGOS.slice();
+      let currentAlgo = null;
+      let streamed = [];
       let initializedTotal = false;
       let dynTotal = 0;
       let nodeSeen = 0;
 
-      uaWorker.onmessage = (ev) => {
-        const data = ev && ev.data ? ev.data : {};
-        if (data && typeof data.candidatesFound === 'number' && CAND_CNT){
-          CAND_CNT.textContent = String(data.candidatesFound);
+      const finishSuccess = (results, algo) => {
+        clearAutoStopTimer();
+        hideProgress();
+        if (BTN_STOP){
+          BTN_STOP.disabled = true;
         }
-        const kind = data.type || data.kind || data.event;
-        if (kind === 'progress' || kind === 'hint'){
-          if ('total' in data && 'done' in data){
-            const panel = ensureProgressPanel();
-            const totalNum = Math.max(1, data.total|0);
-            const currentTotal = parseInt(panel.dataset.total || '0');
-            if (!initializedTotal || currentTotal !== totalNum){
-              showProgress(totalNum);
-              initializedTotal = true;
-            }
-            updateProgress(data.done|0);
-            return;
+        if (BTN_TEST) BTN_TEST.disabled = false;
+        try { if (uaWorker) uaWorker.terminate(); } catch(e){}
+        uaWorker = null;
+        currentJob = null;
+        updateStopVisibility();
+
+        const baseResults = Array.isArray(results) ? results.slice() : [];
+        if (!baseResults.length){
+          if (SUMMARY){
+            const idx = Math.floor(Math.random() * NO_RESULT_MESSAGES.length);
+            setSummaryMessage(NO_RESULT_MESSAGES[idx] || 'No luck this time — give it another whirl!', { noResult: true });
           }
-          const dfs = data.p && data.p.kind === 'dfs' ? data.p : (kind === 'dfs' ? data : null);
-          if (dfs && typeof dfs.nodes === 'number'){
-            nodeSeen = dfs.nodes|0;
-            if (dynTotal < nodeSeen + 100) dynTotal = nodeSeen + 1000;
-            const panel = ensureProgressPanel();
-            const currentTotal = parseInt(panel.dataset.total || '0');
-            if (!initializedTotal || currentTotal !== dynTotal){
-              showProgress(dynTotal);
-              initializedTotal = true;
-            }
-            updateProgress(nodeSeen);
-            return;
-          }
-        }
-        if (kind === 'candidate'){
-          streamed.push(data);
+          if (OUT) OUT.textContent = '';
+          updateHeatMeter(null);
           return;
         }
-        if (kind === 'result' || kind === 'done'){
-          clearAutoStopTimer();
-          hideProgress();
-          if (BTN_STOP){
-            BTN_STOP.disabled = true;
-          }
-          if (BTN_TEST) BTN_TEST.disabled = false;
-          try { uaWorker.terminate(); } catch(e){}
-          uaWorker = null;
-          currentJob = null;
-          updateStopVisibility();
-
-          const baseResults = Array.isArray(data.results) && data.results.length ? data.results : streamed;
-          if (!baseResults.length){
-            if (SUMMARY){
-              const idx = Math.floor(Math.random() * NO_RESULT_MESSAGES.length);
-              setSummaryMessage(NO_RESULT_MESSAGES[idx] || 'No luck this time — give it another whirl!', { noResult: true });
-            }
-            if (OUT) OUT.textContent = '';
-            updateHeatMeter(null);
-            return;
-          }
-          baseResults.sort((a,b)=> (b.score||0) - (a.score||0));
-          const best = baseResults[0];
-          if (!best){
-            if (SUMMARY) setSummaryMessage('We searched the range but did not land on a readable decrypt.', { noResult: true });
-            if (OUT) OUT.textContent = '';
-            updateHeatMeter(null);
-            return;
-          }
-          if (OUT){
-            OUT.textContent = best.full || '';
-          }
-          const stats = computeEnglishStats(best.full || '');
-          const scored = updateHeatMeter(stats);
-          if (SUMMARY){
-            const pct = Math.round((scored.score || 0) * 100);
-            let mood;
-            if (pct >= 90) mood = '🔥 Blazing! That reads like a solved mystery.';
-            else if (pct >= 65) mood = '🌶️ Spicy! The plaintext is almost unlocked.';
-            else if (pct >= 40) mood = '✨ Warming up — a few tweaks might crack it.';
-            else if (pct > 0) mood = '🧊 Still chilly. Try sprinkling in more crib letters.';
-            else mood = 'Add a few more confident letters so the meter can take a proper reading.';
-            setSummaryMessage(`Key length ${best.keyLength}: ${mood} (${pct}% hot)`);
-          }
+        baseResults.sort((a,b)=> (b.score||0) - (a.score||0));
+        const best = baseResults[0];
+        if (!best){
+          if (SUMMARY) setSummaryMessage('We searched the range but did not land on a readable decrypt.', { noResult: true });
+          if (OUT) OUT.textContent = '';
+          updateHeatMeter(null);
+          return;
+        }
+        if (OUT){
+          OUT.textContent = best.full || '';
+        }
+        const stats = computeEnglishStats(best.full || '');
+        const scored = updateHeatMeter(stats);
+        if (SUMMARY){
+          const pct = Math.round((scored.score || 0) * 100);
+          let mood;
+          if (pct >= 90) mood = '🔥 Blazing! That reads like a solved mystery.';
+          else if (pct >= 65) mood = '🌶️ Spicy! The plaintext is almost unlocked.';
+          else if (pct >= 40) mood = '✨ Warming up — a few tweaks might crack it.';
+          else if (pct > 0) mood = '🧊 Still chilly. Try sprinkling in more crib letters.';
+          else mood = 'Add a few more confident letters so the meter can take a proper reading.';
+          const variantLabel = autokeyAlgoLabel(algo);
+          setSummaryMessage(`Key length ${best.keyLength} (${variantLabel}): ${mood} (${pct}% hot)`);
         }
       };
 
-      uaWorker.onerror = (e) => {
-        const msg = e && (e.message || e.toString()) || 'unknown error';
-        stopWorker('Worker error (stopped).', 'Worker error: ' + msg);
+      const finishFailure = () => {
+        clearAutoStopTimer();
+        hideProgress();
+        if (BTN_STOP){
+          BTN_STOP.disabled = true;
+        }
+        if (BTN_TEST) BTN_TEST.disabled = false;
+        try { if (uaWorker) uaWorker.terminate(); } catch(e){}
+        uaWorker = null;
+        currentJob = null;
+        updateStopVisibility();
+        if (SUMMARY){
+          const idx = Math.floor(Math.random() * NO_RESULT_MESSAGES.length);
+          setSummaryMessage(NO_RESULT_MESSAGES[idx] || 'No luck this time — give it another whirl!', { noResult: true });
+        }
+        if (OUT) OUT.textContent = '';
+        updateHeatMeter(null);
       };
 
-      uaWorker.postMessage({ cmd:'start', ...payload });
+      const launchNext = (nextAlgoIndex = 0) => {
+        if (currentJob !== 'unknown'){
+          return;
+        }
+        if (!queue.length){
+          finishFailure();
+          return;
+        }
+        currentAlgo = queue.shift();
+        streamed = [];
+        initializedTotal = false;
+        dynTotal = 0;
+        nodeSeen = 0;
+
+        if (CAND_CNT) CAND_CNT.textContent = '0';
+
+        const variantLabel = autokeyAlgoLabel(currentAlgo);
+        const message = nextAlgoIndex === 0
+          ? `Thinking through the ${variantLabel} autokey twist…`
+          : `No clear text yet — trying the ${variantLabel} autokey twist next…`;
+        if (SUMMARY) setSummaryMessage(message);
+
+        showProgress(1);
+        restartThinkingAnimation(`Thinking — ${variantLabel}`);
+
+        if (uaWorker){ try { uaWorker.terminate(); } catch(e){} }
+        uaWorker = makeWorker();
+
+        uaWorker.onmessage = (ev) => {
+          const data = ev && ev.data ? ev.data : {};
+          if (data && typeof data.candidatesFound === 'number' && CAND_CNT){
+            CAND_CNT.textContent = String(data.candidatesFound);
+          }
+          const kind = data.type || data.kind || data.event;
+          if (currentJob !== 'unknown'){
+            return;
+          }
+          if (kind === 'progress' || kind === 'hint'){
+            if ('total' in data && 'done' in data){
+              const panel = ensureProgressPanel();
+              const totalNum = Math.max(1, data.total|0);
+              const currentTotal = parseInt(panel.dataset.total || '0');
+              if (!initializedTotal || currentTotal !== totalNum){
+                showProgress(totalNum);
+                restartThinkingAnimation(`Thinking — ${variantLabel}`);
+                initializedTotal = true;
+              }
+              updateProgress(data.done|0);
+              return;
+            }
+            const dfs = data.p && data.p.kind === 'dfs' ? data.p : (kind === 'dfs' ? data : null);
+            if (dfs && typeof dfs.nodes === 'number'){
+              nodeSeen = dfs.nodes|0;
+              if (dynTotal < nodeSeen + 100) dynTotal = nodeSeen + 1000;
+              const panel = ensureProgressPanel();
+              const currentTotal = parseInt(panel.dataset.total || '0');
+              if (!initializedTotal || currentTotal !== dynTotal){
+                showProgress(dynTotal);
+                restartThinkingAnimation(`Thinking — ${variantLabel}`);
+                initializedTotal = true;
+              }
+              updateProgress(nodeSeen);
+              return;
+            }
+          }
+          if (kind === 'candidate'){
+            streamed.push(data);
+            return;
+          }
+          if (kind === 'result' || kind === 'done'){
+            hideProgress();
+            try { if (uaWorker) uaWorker.terminate(); } catch(e){}
+            uaWorker = null;
+
+            const baseResults = Array.isArray(data.results) && data.results.length ? data.results : streamed;
+            if (baseResults.length){
+              finishSuccess(baseResults, currentAlgo);
+              return;
+            }
+
+            if (!queue.length){
+              finishFailure();
+              return;
+            }
+
+            if (SUMMARY){
+              const peekLabel = autokeyAlgoLabel(queue[0]);
+              setSummaryMessage(`Still frosty — switching to the ${peekLabel} autokey flavor…`);
+            }
+
+            launchNext(nextAlgoIndex + 1);
+          }
+        };
+
+        uaWorker.onerror = (e) => {
+          const msg = e && (e.message || e.toString()) || 'unknown error';
+          stopWorker('Worker error (stopped).', 'Worker error: ' + msg);
+        };
+
+        const runPayload = { ...payload, autokeyAlgo: currentAlgo };
+        uaWorker.postMessage({ cmd:'start', ...runPayload });
+      };
+
+      launchNext(0);
     }
 
     function startBruteWorker(payload){

--- a/index.html
+++ b/index.html
@@ -28,12 +28,15 @@
       color: var(--ink);
       padding: 32px 18px 54px;
       box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
     }
     h1 { font-size: 28px; margin:0 0 8px; font-weight:800; letter-spacing:-0.01em }
     h2 { font-size: 18px; margin:0 0 12px; font-weight:700 }
     p { margin:0 }
     .hero {
-      max-width: 900px;
+      width: min(960px, 100%);
       margin: 0 auto 24px;
       text-align: center;
     }
@@ -43,7 +46,7 @@
       line-height: 1.5;
     }
     .panels {
-      max-width: 960px;
+      width: min(1280px, 100%);
       margin: 0 auto;
       display: flex;
       flex-direction: column;
@@ -178,6 +181,19 @@
     .muted { color:var(--muted); }
     .legend { display:none }
     .small { font-size:13px }
+    .summary-text {
+      font-size:16px;
+      line-height:1.6;
+      font-weight:600;
+      transition:color .2s ease, transform .2s ease;
+    }
+    .summary-text.no-result {
+      color:var(--accent);
+      font-size:20px;
+      font-weight:800;
+      letter-spacing:0.01em;
+      text-shadow:0 0 20px rgba(56,189,248,0.35);
+    }
     .heat-meter { margin-top:18px; }
     .heat-track {
       position:relative;
@@ -232,10 +248,30 @@
     #progressInner { height:100%; background:linear-gradient(90deg, var(--cold), var(--accent)); width:0%; transition:width .3s ease; }
     @media (max-width: 720px) {
       body { padding:24px 16px; }
+      .hero { width:100%; }
       .panel { padding:20px; }
       .grid { justify-content:center; }
       .cell { width:44px; }
       textarea { min-height:140px; }
+    }
+
+    @media (max-width: 480px) {
+      .controls { justify-content:center; }
+      .controls button { flex:1 1 100%; max-width:280px; }
+      textarea { min-height:160px; }
+    }
+
+    @media (min-width: 1100px) {
+      body { padding:48px 48px 72px; }
+      .hero { width:min(1040px, 100%); }
+      .panels {
+        display:grid;
+        grid-template-columns:repeat(12, minmax(0, 1fr));
+        gap:22px;
+      }
+      #setupPanel, #gridPanel { grid-column:span 6; }
+      #results { grid-column:span 12; }
+      .panel.hidden-control { grid-column:span 12; }
     }
   </style>
 </head>
@@ -286,7 +322,7 @@
 
     <section class="panel" id="results">
       <h2>Step 3 · See how hot your guess is</h2>
-      <div id="summary" class="small muted">No test run yet — add a few guesses to start!</div>
+      <div id="summary" class="summary-text muted">No test run yet — add a few guesses to start!</div>
       <div class="heat-meter">
         <div class="heat-track">
           <div id="heatFill" class="heat-fill" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
@@ -349,6 +385,20 @@ const NO_RESULT_MESSAGES = [
   "Close, but the parchment stays secret. Shuffle your guesses and rerun the test.",
   "The heat meter stayed frosty. Give the puzzle a different sprinkle of clues."
 ];
+
+function setSummaryMessage(text, options){
+  const summary = document.getElementById('summary');
+  if (!summary) return;
+  summary.textContent = text;
+  const opts = options || {};
+  const isNoResult = !!opts.noResult;
+  summary.classList.toggle('no-result', isNoResult);
+  if (isNoResult){
+    summary.classList.remove('muted');
+  } else {
+    summary.classList.add('muted');
+  }
+}
 
 function getQuickTrials(){
   const el = document.getElementById('quickTrialsInput');
@@ -438,15 +488,28 @@ function scoreHeat(stats){
   }
   const chi = Math.max(0, stats.chi || 0);
   const ic = stats.ic || 0;
-  const chiComponent = clamp01(1 / (1 + chi / 55));
-  const iocTarget = 0.0667;
-  const iocSpread = 0.015;
-  const iocComponent = clamp01(Math.exp(-Math.abs(ic - iocTarget) / iocSpread));
-  const lengthConfidence = clamp01((stats.length || 0) / 120);
-  const base = (chiComponent * 0.55) + (iocComponent * 0.45);
-  const boosted = base * (0.45 + (0.55 * lengthConfidence));
-  const score = clamp01(boosted);
-  return { score, chi: chi, ic, length: stats.length };
+  const length = stats.length || 0;
+  const chiSweetSpot = 20;
+  const chiDecay = 45;
+  let chiComponent;
+  if (chi <= chiSweetSpot){
+    chiComponent = 1;
+  } else {
+    chiComponent = Math.exp(-(chi - chiSweetSpot) / chiDecay);
+  }
+  chiComponent = clamp01(chiComponent);
+  const iocTarget = 0.066;
+  const iocTolerance = 0.005;
+  const iocComponent = clamp01(Math.exp(-Math.pow(ic - iocTarget, 2) / (2 * iocTolerance * iocTolerance)));
+  const lengthConfidence = clamp01(length / 80);
+  let baseScore = (chiComponent * 0.6) + (iocComponent * 0.4);
+  if (chi <= chiSweetSpot && Math.abs(ic - iocTarget) <= iocTolerance){
+    baseScore = 1;
+  } else {
+    baseScore *= 0.55 + (0.45 * lengthConfidence);
+  }
+  const score = clamp01(baseScore);
+  return { score, chi, ic, length };
 }
 
 function updateHeatMeter(stats){
@@ -486,10 +549,7 @@ function updateHeatMeter(stats){
 
 function resetHeatMeter(){
   updateHeatMeter(null);
-  const summary = document.getElementById('summary');
-  if (summary){
-    summary.textContent = 'No test run yet — add a few guesses to start!';
-  }
+  setSummaryMessage('No test run yet — add a few guesses to start!');
 }
 
 const AUTOKEY_ALGOS = ['vigenere','beaufort','beaufort_variant'];
@@ -1049,15 +1109,13 @@ function testCribs(){
   const minK = parseInt(document.getElementById('minK').value);
   const maxK = parseInt(document.getElementById('maxK').value);
   const out = document.getElementById('out');
-  const summary = document.getElementById('summary');
-
   out.textContent = '';
   if ((op !== 'vig_sub' && op !== 'vig_sub_post') && segments.length === 0){
-    summary.textContent = 'No crib segments entered — enter letters under ciphertext characters.';
+    setSummaryMessage('No crib segments entered — enter letters under ciphertext characters.');
     return;
   }
 
-  summary.textContent = `Testing ${segments.length} crib segment(s) for key lengths ${minK}..${maxK} using ${op}`;
+  setSummaryMessage(`Testing ${segments.length} crib segment(s) for key lengths ${minK}..${maxK} using ${op}`);
 
   if (op === 'vigenere'){
     const {cLetters} = buildLetterStreams(letters);
@@ -2051,9 +2109,8 @@ async function runUnknownAlphabetInline(){
   const minK = parseInt(document.getElementById('minK').value);
   const maxK = parseInt(document.getElementById('maxK').value);
   const out = document.getElementById('out');
-  const summary = document.getElementById('summary');
   out.textContent='';
-  if (segments.length === 0){ summary.textContent='Enter at least one crib segment.'; return; }
+  if (segments.length === 0){ setSummaryMessage('Enter at least one crib segment.'); return; }
   const total = (maxK - minK + 1);
   const isVigMode = (op === 'vig_custom_alpha');
   const autokeyAlgo = currentAutokeyAlgo();
@@ -2125,11 +2182,11 @@ async function runUnknownAlphabetInline(){
         const contrad = false;
         debugLines.push(`m=${kLen}: constraints=${cons.length}, residuesHit=${cover}/${kLen}, contradictions=${contrad}`);
       }
-      summary.textContent = `No solution for key lengths ${minK}..${maxK} under this model.`;
+      setSummaryMessage(`No solution for key lengths ${minK}..${maxK} under this model.`, { noResult: true });
       const pre = document.createElement('pre'); pre.className='small muted'; pre.textContent = debugLines.join('\n');
       out.appendChild(pre);
     } else {
-      summary.textContent = `No solution for key lengths ${minK}..${maxK} under autokey + unknown alphabet (${autokeyLabel}).`;
+      setSummaryMessage(`No solution for key lengths ${minK}..${maxK} under autokey + unknown alphabet (${autokeyLabel}).`, { noResult: true });
       const pre = document.createElement('pre'); pre.className='small muted';
       const detailLines = [];
       for (const {m, coverage} of coveragePerM){
@@ -2182,9 +2239,11 @@ try{
   }
 }catch(e){ console.warn('Summary render failed', e); }
 
-  summary.textContent = isVigMode
-    ? `Found ${results.length} solution(s) for unknown alphabet Vigenère.`
-    : `Found ${results.length} solution(s) for autokey + unknown alphabet (${autokeyLabel}).`;
+  setSummaryMessage(
+    isVigMode
+      ? `Found ${results.length} solution(s) for unknown alphabet Vigenère.`
+      : `Found ${results.length} solution(s) for autokey + unknown alphabet (${autokeyLabel}).`
+  );
   results.slice(0,50).forEach((r,idx)=>{
     const div=document.createElement('div'); div.className='row';
     const keyDisplay = (!isVigMode && r.actualKey) ? r.actualKey : r.key;
@@ -3410,7 +3469,7 @@ try{
         if (typeof outText === 'string' && BRUTE_OUT) BRUTE_OUT.textContent = outText;
       } else {
         if (BTN_TEST) BTN_TEST.disabled = false;
-        if (typeof summaryText === 'string' && SUMMARY) SUMMARY.textContent = summaryText;
+        if (typeof summaryText === 'string' && SUMMARY) setSummaryMessage(summaryText);
         if (typeof outText === 'string' && OUT) OUT.textContent = outText;
       }
       updateHeatMeter(null);
@@ -3423,7 +3482,7 @@ try{
     function startWorkerSolve(){
       const payload = gatherForWorker();
       if (!payload.cribPairs.length){
-        if (SUMMARY) SUMMARY.textContent = 'Enter at least one crib segment first.';
+        if (SUMMARY) setSummaryMessage('Enter at least one crib segment first.');
         return;
       }
       const isAutokey = payload.op === 'autokey_custom_alpha';
@@ -3439,7 +3498,7 @@ try{
         BTN_STOP.disabled = false;
       }
       updateStopVisibility();
-      if (SUMMARY) SUMMARY.textContent = `Running ${modeLabel}…`;
+      if (SUMMARY) setSummaryMessage(`Running ${modeLabel}…`);
       if (OUT) OUT.textContent = '';
       if (CAND_CNT) CAND_CNT.textContent = '0';
       showProgress(1, 'Estimating search space…');
@@ -3504,7 +3563,7 @@ try{
           if (!baseResults.length){
             if (SUMMARY){
               const idx = Math.floor(Math.random() * NO_RESULT_MESSAGES.length);
-              SUMMARY.textContent = NO_RESULT_MESSAGES[idx] || 'No luck this time — give it another whirl!';
+              setSummaryMessage(NO_RESULT_MESSAGES[idx] || 'No luck this time — give it another whirl!', { noResult: true });
             }
             if (OUT) OUT.textContent = '';
             updateHeatMeter(null);
@@ -3513,7 +3572,7 @@ try{
           baseResults.sort((a,b)=> (b.score||0) - (a.score||0));
           const best = baseResults[0];
           if (!best){
-            if (SUMMARY) SUMMARY.textContent = 'We searched the range but did not land on a readable decrypt.';
+            if (SUMMARY) setSummaryMessage('We searched the range but did not land on a readable decrypt.', { noResult: true });
             if (OUT) OUT.textContent = '';
             updateHeatMeter(null);
             return;
@@ -3531,7 +3590,7 @@ try{
             else if (pct >= 40) mood = '✨ Warming up — a few tweaks might crack it.';
             else if (pct > 0) mood = '🧊 Still chilly. Try sprinkling in more crib letters.';
             else mood = 'Add a few more confident letters so the meter can take a proper reading.';
-            SUMMARY.textContent = `Key length ${best.keyLength}: ${mood} (${pct}% hot)`;
+            setSummaryMessage(`Key length ${best.keyLength}: ${mood} (${pct}% hot)`);
           }
         }
       };

--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
       gap:18px;
       z-index:40;
       backdrop-filter:blur(12px);
+      -webkit-backdrop-filter:blur(12px);
     }
     #results {
       max-height:min(420px, 70vh);
@@ -144,6 +145,7 @@
       border:1px solid rgba(148,163,184,0.12);
       align-items:flex-start;
       overflow-x:auto;
+      -webkit-overflow-scrolling:touch;
     }
     .word {
       display:flex;
@@ -281,21 +283,6 @@
       font-weight:600;
       color:var(--muted);
     }
-    .stat-chips {
-      display:flex;
-      gap:12px;
-      flex-wrap:wrap;
-      margin-top:14px;
-    }
-    .chip {
-      background:rgba(8,17,35,0.85);
-      color:var(--muted);
-      padding:8px 14px;
-      border-radius:999px;
-      font-weight:700;
-      font-size:13px;
-      border:1px solid rgba(56,189,248,0.18);
-    }
     .hidden-control { display:none !important; }
     #progressPanel { display:none; width:100%; }
     #progressLabel { font-weight:800; font-size:22px; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); text-shadow:0 0 26px rgba(56,189,248,0.35); }
@@ -327,7 +314,9 @@
       .hero { width:100%; }
       .panel { padding:20px; }
       .grid { justify-content:center; }
-      .cell { width:44px; }
+      .cell { width:40px; }
+      .char { padding:6px 0; font-size:14px; }
+      input.cribin { min-height:40px; padding:8px 0; font-size:18px; }
       textarea { min-height:140px; }
       .floating-panel {
         width:calc(100% - 24px);
@@ -341,6 +330,10 @@
     @media (max-width: 480px) {
       .controls { justify-content:center; }
       .controls button { flex:1 1 100%; max-width:280px; }
+      .grid { gap:12px 10px; }
+      .cell { width:34px; }
+      .char { padding:5px 0; font-size:13px; }
+      input.cribin { min-height:36px; padding:6px 0; font-size:16px; }
       textarea { min-height:160px; }
       .floating-panel { bottom:calc(18px + env(safe-area-inset-bottom, 0px)); }
     }
@@ -419,10 +412,6 @@
         </div>
         <div class="heat-labels"><span>Cold</span><span>Hot!</span></div>
       </div>
-      <div class="stat-chips">
-        <div class="chip" id="chiStat">χ²: —</div>
-        <div class="chip" id="iocStat">IOC: —</div>
-      </div>
       <pre id="out"></pre>
     </section>
 
@@ -475,6 +464,16 @@ let confettiCooling = false;
 let lastHeatScore = 0;
 let thinkingInterval = null;
 let thinkingIndex = 0;
+
+function shouldDeferAutoFocus(){
+  if (typeof window === 'undefined') return false;
+  const nav = (typeof navigator !== 'undefined') ? navigator : null;
+  const touchPoints = nav && typeof nav.maxTouchPoints === 'number' ? nav.maxTouchPoints : 0;
+  const hasTouch = ('ontouchstart' in window) || touchPoints > 0;
+  const ua = nav && nav.userAgent ? nav.userAgent : '';
+  const isiOS = /iPad|iPhone|iPod/.test(ua);
+  return hasTouch || isiOS;
+}
 
 function triggerConfetti(){
   if (confettiCooling) return;
@@ -669,9 +668,7 @@ function scoreHeat(stats){
 
 function updateHeatMeter(stats){
   const heatFill = document.getElementById('heatFill');
-  const chiStat = document.getElementById('chiStat');
-  const iocStat = document.getElementById('iocStat');
-  if (!heatFill || !chiStat || !iocStat){
+  if (!heatFill){
     return { score: 0, chi: 0, ic: 0 };
   }
   if (!stats || !stats.length){
@@ -682,8 +679,6 @@ function updateHeatMeter(stats){
     heatFill.setAttribute('aria-valuenow', '0');
     heatFill.setAttribute('aria-valuemin', '0');
     heatFill.setAttribute('aria-valuemax', '100');
-    chiStat.textContent = 'χ²: —';
-    iocStat.textContent = 'IOC: —';
     return { score: 0, chi: 0, ic: 0 };
   }
   const scored = scoreHeat(stats);
@@ -700,10 +695,6 @@ function updateHeatMeter(stats){
     triggerConfetti();
   }
   lastHeatScore = pct;
-  const chiVal = scored.chi.toFixed(2);
-  const iocVal = scored.ic.toFixed(4);
-  chiStat.textContent = `χ²: ${chiVal}`;
-  iocStat.textContent = `IOC: ${iocVal}`;
   return scored;
 }
 
@@ -824,12 +815,15 @@ function renderGrid(){
   const grid = document.getElementById('grid');
   grid.innerHTML = '';
 
+  const fragment = document.createDocumentFragment();
+
   let letterIndex = 0;
   let wordWrap = null;
+  let firstEditableInput = null;
 
   const flushWord = () => {
     if (wordWrap && wordWrap.childNodes.length){
-      grid.appendChild(wordWrap);
+      fragment.appendChild(wordWrap);
     }
     wordWrap = null;
   };
@@ -856,7 +850,7 @@ function renderGrid(){
       flushWord();
       const breaker = document.createElement('div');
       breaker.className = 'line-break';
-      grid.appendChild(breaker);
+      fragment.appendChild(breaker);
       return;
     }
 
@@ -864,7 +858,7 @@ function renderGrid(){
       flushWord();
       const spacer = document.createElement('div');
       spacer.className = 'word-gap';
-      grid.appendChild(spacer);
+      fragment.appendChild(spacer);
       return;
     }
 
@@ -883,10 +877,14 @@ function renderGrid(){
 
     const crib = document.createElement('input');
     crib.className = 'cribin';
+    crib.type = 'text';
     crib.maxLength = 1;
     crib.dataset.pos = idx;
     crib.placeholder = '';
     crib.title = 'Type a single plaintext letter (or leave blank)';
+    crib.autocomplete = 'off';
+    crib.autocapitalize = 'characters';
+    crib.inputMode = 'latin';
 
     if (!isLetter(ch)){
       crib.disabled = true;
@@ -894,6 +892,9 @@ function renderGrid(){
     } else {
       cell.dataset.letterIdx = letterIndex;
       letterIndex++;
+      if (!firstEditableInput){
+        firstEditableInput = crib;
+      }
 
       // Selection mode click handler
       cell.addEventListener('click', (e) => {
@@ -938,9 +939,11 @@ function renderGrid(){
   });
 
   flushWord();
+  grid.appendChild(fragment);
 
-  const first = grid.querySelector('input.cribin:not([disabled])');
-  if (first) first.focus();
+  if (firstEditableInput && !shouldDeferAutoFocus()){
+    firstEditableInput.focus();
+  }
 }
 // ===== Data extraction =====
 function gatherCribs(){

--- a/index.html
+++ b/index.html
@@ -20,18 +20,6 @@
       font-family:'Nunito', 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
     }
     *, *::before, *::after { box-sizing:border-box; }
-    .thinking-panel {
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      text-align:center;
-      min-height:96px;
-      background:rgba(255,255,255,0.85);
-      border-radius:18px;
-      border:1px solid rgba(251,207,232,0.6);
-      box-shadow:0 18px 38px rgba(180,206,145,0.35);
-      padding:18px;
-    }
     .thinking-text {
       font-size:22px;
       font-weight:800;
@@ -123,11 +111,81 @@
       flex-direction:column;
       gap:8px;
     }
+    .floating-actions {
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+    .floating-action-row {
+      display:flex;
+      gap:12px;
+      align-items:center;
+      justify-content:center;
+      flex-wrap:wrap;
+    }
+    #floatingTestRow {
+      display:none;
+      justify-content:center;
+    }
+    .results-cta {
+      padding:12px 26px;
+      border-radius:999px;
+      border:none;
+      font-weight:800;
+      letter-spacing:0.02em;
+      cursor:pointer;
+      background:linear-gradient(135deg, #bef264, #fbcfe8);
+      color:#134e4a;
+      box-shadow:0 20px 34px rgba(186,230,253,0.45);
+      transition:transform .15s ease, box-shadow .2s ease;
+    }
+    .results-cta:hover {
+      transform:translateY(-1px);
+      box-shadow:0 24px 42px rgba(186,230,253,0.5);
+    }
+    .results-cta:disabled {
+      opacity:.45;
+      cursor:not-allowed;
+      box-shadow:none;
+      transform:none;
+    }
+    #progressPanel {
+      display:none;
+      width:100%;
+      justify-content:center;
+      gap:12px;
+      flex-wrap:wrap;
+    }
+    #progressLabel {
+      font-size:18px;
+    }
+    .results-stop {
+      padding:10px 18px;
+      border-radius:999px;
+      font-weight:700;
+      cursor:pointer;
+      background:rgba(255,255,255,0.9);
+      color:var(--muted);
+      border:1px solid rgba(190,242,100,0.6);
+      box-shadow:0 14px 28px rgba(214,232,200,0.55);
+      transition:transform .15s ease, box-shadow .2s ease;
+    }
+    .results-stop:hover {
+      transform:translateY(-1px);
+      box-shadow:0 18px 32px rgba(214,232,200,0.65);
+    }
+    .results-stop:disabled {
+      opacity:.45;
+      cursor:not-allowed;
+      transform:none;
+      box-shadow:none;
+    }
     .results-toggle {
+      align-self:flex-end;
       display:none;
       align-items:center;
       justify-content:center;
-      padding:8px 16px;
+      padding:8px 18px;
       border-radius:999px;
       border:1px solid rgba(244,114,182,0.35);
       background:rgba(244,114,182,0.18);
@@ -149,9 +207,7 @@
       flex-direction:column;
       gap:18px;
     }
-    .floating-panel.collapsed .floating-body {
-      display:none;
-    }
+    .floating-panel.collapsed .floating-body { display:none; }
     #results {
       max-height:min(420px, 70vh);
       overflow-y:auto;
@@ -361,8 +417,7 @@
       color:var(--muted);
     }
     .hidden-control { display:none !important; }
-    #progressPanel { display:none; width:100%; }
-    #progressLabel { font-weight:800; font-size:22px; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); text-shadow:0 0 26px rgba(244,114,182,0.35); }
+    #progressLabel { font-weight:800; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); text-shadow:0 0 26px rgba(244,114,182,0.35); }
 
     .confetti-container {
       position:fixed;
@@ -401,6 +456,8 @@
         padding:22px 22px 24px;
         border-radius:20px;
       }
+      #floatingTestRow { display:flex; }
+      .floating-actions { gap:14px; }
       .floating-header { flex-direction:column; align-items:flex-start; gap:12px; }
       .results-toggle { display:inline-flex; align-self:flex-end; }
       .floating-panel.collapsed { padding:18px 18px 20px; }
@@ -446,7 +503,7 @@
 
   <div class="panels">
     <section class="panel" id="setupPanel">
-      <h2>Step 1 · Meet the mystery</h2>
+      <h2>Meet the mystery</h2>
       <p class="muted">We've loaded a puzzling cipher that keeps all punctuation and spacing intact so everything lines up perfectly while you solve.</p>
       <div class="hidden-control">
         <textarea id="ctext">Rc qipv jhx vld plson fhceuh itp jui gh qhzu dg sq xie dhw. U gbfl lf fluz pcag wrgkv zw, dinyg zw, qge gnvm L fhx.</textarea>
@@ -480,7 +537,7 @@
     </section>
 
     <section class="panel" id="gridPanel">
-      <h2>Step 2 · Fill in what you know</h2>
+      <h2>Fill in what you know</h2>
       <p class="muted">Click under each letter and type your guess. We'll only let you edit the spots that are real letters.</p>
       <div id="grid" class="grid"></div>
     </section>
@@ -488,18 +545,27 @@
     <section class="floating-panel" id="results">
       <div class="floating-header">
         <div class="floating-title">
-          <h2>Step 3 · See how hot your guess is</h2>
+          <h2>Results</h2>
           <div id="summary" class="summary-text muted">No test run yet — add a few guesses to start!</div>
         </div>
-        <button type="button" id="resultsToggle" class="results-toggle" aria-expanded="true" aria-controls="resultsBody">Hide details</button>
       </div>
-      <div class="floating-body" id="resultsBody">
+      <div class="floating-actions" id="resultsActions">
+        <div class="floating-action-row" id="floatingTestRow">
+          <button id="testFloating" type="button" class="results-cta">Test My Guess</button>
+        </div>
+        <div class="floating-action-row" id="progressPanel">
+          <div id="progressLabel" class="thinking-text">Thinking...</div>
+          <button id="stopFloating" type="button" class="results-stop secondary">Stop Thinking</button>
+        </div>
         <div class="heat-meter">
           <div class="heat-track">
             <div id="heatFill" class="heat-fill" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
           </div>
           <div class="heat-labels"><span>Cold</span><span>Hot!</span></div>
         </div>
+        <button type="button" id="resultsToggle" class="results-toggle" aria-expanded="true" aria-controls="resultsBody">Hide results</button>
+      </div>
+      <div class="floating-body" id="resultsBody">
         <pre id="out"></pre>
       </div>
     </section>
@@ -595,7 +661,7 @@ function updateResultsToggleVisibility(){
   toggle.style.display = mobile ? 'inline-flex' : 'none';
   if (!mobile){
     toggle.setAttribute('aria-expanded', 'true');
-    toggle.textContent = 'Hide details';
+    toggle.textContent = 'Hide results';
   }
 }
 
@@ -611,10 +677,10 @@ function setResultsCollapsed(collapsed){
   }
   if (toggle){
     if (mobile){
-      toggle.textContent = shouldCollapse ? 'Show details' : 'Hide details';
+      toggle.textContent = shouldCollapse ? 'See results' : 'Hide results';
       toggle.setAttribute('aria-expanded', String(!shouldCollapse));
     } else {
-      toggle.textContent = 'Hide details';
+      toggle.textContent = 'Hide results';
       toggle.setAttribute('aria-expanded', 'true');
     }
   }
@@ -623,6 +689,7 @@ function setResultsCollapsed(collapsed){
 function handleResultsMediaChange(){
   updateResultsToggleVisibility();
   setResultsCollapsed(resultsCollapsed);
+  setFloatingThinking(!!currentJob);
 }
 
 function initResultsPanel(){
@@ -689,6 +756,7 @@ function updateThinkingLabel(){
 
 function restartThinkingAnimation(baseLabel){
   const panel = ensureProgressPanel();
+  if (!panel) return;
   panel.dataset.baseLabel = baseLabel || 'Thinking';
   thinkingIndex = 0;
   updateThinkingLabel();
@@ -1764,30 +1832,34 @@ document.getElementById('bruteForce').addEventListener('click', bruteForceWordli
 
 // ===== Progress (lazy) =====
 function ensureProgressPanel(){
-  let panel = document.getElementById('progressPanel');
-  if (panel) return panel;
-  const after = document.getElementById('out');
-  panel = document.createElement('div');
-  panel.id = 'progressPanel';
-  panel.className = 'thinking-panel';
-  const lab = document.createElement('div');
-  lab.id = 'progressLabel';
-  lab.className = 'thinking-text';
-  lab.textContent = 'Thinking...';
-  panel.appendChild(lab);
-  if (after && after.parentNode){
-    after.parentNode.insertBefore(panel, after.nextSibling);
-  } else {
-    document.body.appendChild(panel);
+  return document.getElementById('progressPanel');
+}
+
+function setFloatingThinking(isThinking){
+  const testRow = document.getElementById('floatingTestRow');
+  const panel = ensureProgressPanel();
+  if (testRow){
+    if (isMobileResultsView()){
+      testRow.style.display = isThinking ? 'none' : 'flex';
+    } else {
+      testRow.style.display = '';
+    }
   }
-  return panel;
+  if (panel){
+    panel.style.display = isThinking ? 'flex' : 'none';
+  }
+  if (BTN_STOP_FLOAT){
+    BTN_STOP_FLOAT.disabled = !isThinking;
+  }
 }
 function showProgress(total){
   const panel = ensureProgressPanel();
-  panel.style.display = 'flex';
-  panel.dataset.total = String(Math.max(1, total || 1));
-  panel.dataset.done = '0';
+  if (panel){
+    panel.dataset.total = String(Math.max(1, total || 1));
+    panel.dataset.done = '0';
+  }
   lastHeatScore = 0;
+  setFloatingThinking(true);
   restartThinkingAnimation('Thinking');
 }
 function updateProgress(done){
@@ -1800,6 +1872,7 @@ function hideProgress(){
   if (panel){
     panel.style.display = 'none';
   }
+  setFloatingThinking(false);
   stopThinkingAnimation();
 }
 function uiYield(){ return new Promise(r=>setTimeout(r,0)); }
@@ -2648,6 +2721,8 @@ try{
     function $(id){ return document.getElementById(id); }
     const BTN_TEST = $("test");
     const BTN_STOP = $("stopSearch");
+    const BTN_TEST_FLOAT = $("testFloating");
+    const BTN_STOP_FLOAT = $("stopFloating");
     const SEL_OP   = $("op");
     const SEL_AUTOKEY_ALGO = $("autokeyAlgo");
     const LBL_AUTOKEY_ALGO = $("autokeyAlgoLabel");
@@ -2679,13 +2754,14 @@ try{
     if (SEL_AUTOKEY_ALGO){
       SEL_AUTOKEY_ALGO.value = normalizeAutokeyAlgo(SEL_AUTOKEY_ALGO.value);
     }
-    updateAutokeyAlgoVisibility();
-    resetHeatMeter();
-    initResultsPanel();
-
     let uaWorker = null;
     let currentJob = null;
     let bruteCtx = null;
+
+    updateAutokeyAlgoVisibility();
+    resetHeatMeter();
+    initResultsPanel();
+    setFloatingThinking(false);
 
     const AUTO_STOP_MS = 15000;
     const AUTO_STOP_MESSAGE = "Hmm… I need a little more information to confirm this one — try adding more crib letters and test again!";
@@ -3848,6 +3924,9 @@ try{
       if (BTN_STOP){
         BTN_STOP.disabled = true;
       }
+      if (BTN_STOP_FLOAT){
+        BTN_STOP_FLOAT.disabled = true;
+      }
     }
 
     function updateStopVisibility(){
@@ -3872,6 +3951,7 @@ try{
         if (typeof outText === 'string' && BRUTE_OUT) BRUTE_OUT.textContent = outText;
       } else {
         if (BTN_TEST) BTN_TEST.disabled = false;
+        if (BTN_TEST_FLOAT) BTN_TEST_FLOAT.disabled = false;
         if (typeof summaryText === 'string' && SUMMARY) setSummaryMessage(summaryText);
         if (typeof outText === 'string' && OUT) OUT.textContent = outText;
       }
@@ -3892,8 +3972,12 @@ try{
       bruteCtx = null;
 
       if (BTN_TEST) BTN_TEST.disabled = true;
+      if (BTN_TEST_FLOAT) BTN_TEST_FLOAT.disabled = true;
       if (BTN_STOP){
         BTN_STOP.disabled = false;
+      }
+      if (BTN_STOP_FLOAT){
+        BTN_STOP_FLOAT.disabled = false;
       }
       updateStopVisibility();
       if (OUT) OUT.textContent = '';
@@ -3914,7 +3998,11 @@ try{
         if (BTN_STOP){
           BTN_STOP.disabled = true;
         }
+        if (BTN_STOP_FLOAT){
+          BTN_STOP_FLOAT.disabled = true;
+        }
         if (BTN_TEST) BTN_TEST.disabled = false;
+        if (BTN_TEST_FLOAT) BTN_TEST_FLOAT.disabled = false;
         try { if (uaWorker) uaWorker.terminate(); } catch(e){}
         uaWorker = null;
         currentJob = null;
@@ -3961,7 +4049,11 @@ try{
         if (BTN_STOP){
           BTN_STOP.disabled = true;
         }
+        if (BTN_STOP_FLOAT){
+          BTN_STOP_FLOAT.disabled = true;
+        }
         if (BTN_TEST) BTN_TEST.disabled = false;
+        if (BTN_TEST_FLOAT) BTN_TEST_FLOAT.disabled = false;
         try { if (uaWorker) uaWorker.terminate(); } catch(e){}
         uaWorker = null;
         currentJob = null;
@@ -4206,23 +4298,33 @@ try{
       uaWorker.postMessage({ cmd:'bruteforce', ...payload });
     }
 
+    function handleStop(ev){
+      ev.preventDefault();
+      const msg = currentJob === 'brute' ? 'Brute force cancelled.' : 'Search cancelled.';
+      stopWorker(msg);
+    }
+
     if (BTN_STOP){
-      BTN_STOP.addEventListener('click', (ev)=>{
+      BTN_STOP.addEventListener('click', handleStop);
+    }
+    if (BTN_STOP_FLOAT){
+      BTN_STOP_FLOAT.addEventListener('click', handleStop);
+    }
+
+    function handleTest(ev){
+      const op = SEL_OP ? SEL_OP.value : '';
+      if (op === 'vig_custom_alpha' || op === 'autokey_custom_alpha'){
         ev.preventDefault();
-        const msg = currentJob === 'brute' ? 'Brute force cancelled.' : 'Search cancelled.';
-        stopWorker(msg);
-      });
+        ev.stopImmediatePropagation();
+        startWorkerSolve();
+      }
     }
 
     if (BTN_TEST){
-      BTN_TEST.addEventListener('click', (ev)=>{
-        const op = SEL_OP ? SEL_OP.value : '';
-        if (op === 'vig_custom_alpha' || op === 'autokey_custom_alpha'){
-          ev.preventDefault();
-          ev.stopImmediatePropagation();
-          startWorkerSolve();
-        }
-      }, true);
+      BTN_TEST.addEventListener('click', handleTest, true);
+    }
+    if (BTN_TEST_FLOAT){
+      BTN_TEST_FLOAT.addEventListener('click', handleTest, true);
     }
 
     if (SEL_OP){

--- a/index.html
+++ b/index.html
@@ -5,8 +5,6 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Puzzle Decrypter Playground</title>
   <style>
-#progressBar{background:#f97316;height:100%;width:0%;transition:width .3s ease}
-
     :root{
       --bg:#020617;
       --panel:#0f172a;
@@ -20,6 +18,21 @@
       --hot:#f97316;
       --cold:#38bdf8;
       font-family:'Nunito', 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    }
+    .thinking-panel {
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      text-align:center;
+      min-height:110px;
+    }
+    .thinking-text {
+      font-size:22px;
+      font-weight:800;
+      letter-spacing:0.12em;
+      text-transform:uppercase;
+      color:var(--accent);
+      text-shadow:0 0 26px rgba(56,189,248,0.35);
     }
     body {
       margin: 0;
@@ -252,17 +265,31 @@
       border:1px solid rgba(56,189,248,0.18);
     }
     .hidden-control { display:none !important; }
-    #progressWrap {
-      display:none;
-      margin-top:14px;
-      background:rgba(15,23,42,0.9);
-      border-radius:999px;
-      height:18px;
+    #progressPanel { display:none; }
+    #progressLabel { font-weight:800; font-size:22px; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); text-shadow:0 0 26px rgba(56,189,248,0.35); }
+
+    .confetti-container {
+      position:fixed;
+      inset:0;
+      pointer-events:none;
       overflow:hidden;
-      border:1px solid rgba(56,189,248,0.2);
+      z-index:9999;
     }
-    #progressLabel { margin-top:8px; font-weight:600; color:var(--muted); }
-    #progressInner { height:100%; background:linear-gradient(90deg, var(--cold), var(--accent)); width:0%; transition:width .3s ease; }
+    .confetti-piece {
+      position:absolute;
+      top:-12vh;
+      width:8px;
+      height:18px;
+      border-radius:3px;
+      opacity:0;
+      transform:translate3d(0,-120vh,0) rotate(0deg);
+      animation:confettiFall 2.2s ease-in forwards;
+    }
+    @keyframes confettiFall {
+      0% { opacity:0; transform:translate3d(0,-120vh,0) rotate(0deg); }
+      10% { opacity:1; }
+      100% { opacity:0; transform:translate3d(var(--confetti-x, 0px), 120vh, 0) rotate(360deg); }
+    }
     @media (max-width: 720px) {
       body { padding:24px 16px; }
       .hero { width:100%; }
@@ -333,7 +360,7 @@
 
       <div class="controls">
         <button id="render" class="secondary">Refresh Puzzle</button>
-        <button id="stopSearch" class="secondary" disabled>Stop Search</button>
+        <button id="stopSearch" class="secondary" disabled>Stop Thinking</button>
         <button id="test">Test My Guess</button>
       </div>
     </section>
@@ -402,6 +429,71 @@ const isLetter = ch => /[A-Za-z]/.test(ch);
 const sanitize = s => s.toUpperCase().replace(/[^A-Z]/g,'');
 
 let wordlist = [];
+
+const CONFETTI_COLORS = ['#38bdf8', '#f97316', '#a855f7', '#22d3ee', '#facc15'];
+const THINKING_STATES = ['.', '..', '...'];
+let confettiCooling = false;
+let lastHeatScore = 0;
+let thinkingInterval = null;
+let thinkingIndex = 0;
+
+function triggerConfetti(){
+  if (confettiCooling) return;
+  confettiCooling = true;
+  const container = document.createElement('div');
+  container.className = 'confetti-container';
+  const pieceCount = 110;
+  for (let i = 0; i < pieceCount; i++){
+    const piece = document.createElement('span');
+    piece.className = 'confetti-piece';
+    piece.style.background = CONFETTI_COLORS[i % CONFETTI_COLORS.length];
+    piece.style.left = `${Math.random() * 100}%`;
+    piece.style.width = `${5 + Math.random() * 6}px`;
+    piece.style.height = `${10 + Math.random() * 12}px`;
+    piece.style.animationDelay = `${Math.random() * 0.6}s`;
+    piece.style.animationDuration = `${1.6 + Math.random() * 0.9}s`;
+    piece.style.transform = `rotate(${Math.random() * 360}deg)`;
+    piece.style.setProperty('--confetti-x', `${(Math.random() * 220) - 110}px`);
+    container.appendChild(piece);
+  }
+  document.body.appendChild(container);
+  setTimeout(() => {
+    container.remove();
+  }, 2300);
+  setTimeout(() => {
+    confettiCooling = false;
+  }, 1200);
+}
+
+function updateThinkingLabel(){
+  const label = document.getElementById('progressLabel');
+  const panel = document.getElementById('progressPanel');
+  if (!label || !panel) return;
+  const base = panel.dataset.baseLabel || 'Thinking';
+  const suffix = THINKING_STATES[thinkingIndex % THINKING_STATES.length];
+  label.textContent = `${base}${suffix}`;
+}
+
+function restartThinkingAnimation(baseLabel){
+  const panel = ensureProgressPanel();
+  panel.dataset.baseLabel = baseLabel || 'Thinking';
+  thinkingIndex = 0;
+  updateThinkingLabel();
+  if (thinkingInterval){
+    clearInterval(thinkingInterval);
+  }
+  thinkingInterval = setInterval(() => {
+    thinkingIndex = (thinkingIndex + 1) % THINKING_STATES.length;
+    updateThinkingLabel();
+  }, 520);
+}
+
+function stopThinkingAnimation(){
+  if (thinkingInterval){
+    clearInterval(thinkingInterval);
+    thinkingInterval = null;
+  }
+}
 
 const NO_RESULT_MESSAGES = [
   "That wasn't it! The cipher sprites are asking for another guess.",
@@ -544,6 +636,7 @@ function updateHeatMeter(stats){
     return { score: 0, chi: 0, ic: 0 };
   }
   if (!stats || !stats.length){
+    lastHeatScore = 0;
     heatFill.style.width = '0%';
     heatFill.style.opacity = '0.35';
     heatFill.style.boxShadow = 'none';
@@ -564,6 +657,10 @@ function updateHeatMeter(stats){
   heatFill.setAttribute('aria-valuenow', String(pct));
   heatFill.setAttribute('aria-valuemin', '0');
   heatFill.setAttribute('aria-valuemax', '100');
+  if (pct >= 96 && pct > lastHeatScore){
+    triggerConfetti();
+  }
+  lastHeatScore = pct;
   const chiVal = scored.chi.toFixed(2);
   const iocVal = scored.ic.toFixed(4);
   chiStat.textContent = `χ²: ${chiVal}`;
@@ -1450,42 +1547,41 @@ function ensureProgressPanel(){
   let panel = document.getElementById('progressPanel');
   if (panel) return panel;
   const after = document.getElementById('out');
-  panel = document.createElement('div'); panel.id='progressPanel'; panel.className='panel';
-  const lab = document.createElement('div'); lab.id='progressLabel'; lab.className='small muted'; lab.textContent='Working…';
-  const wrap = document.createElement('div'); wrap.style.cssText='position:relative;height:14px;background:rgba(255,255,255,0.08);border-radius:6px;overflow:hidden;margin-top:6px';
-  const bar = document.createElement('div'); bar.id='progressBar'; bar.style.cssText='height:100%;width:0%';
-  const pct = document.createElement('div'); pct.id='progressPct'; pct.style.cssText='position:absolute;left:0;top:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;font-size:12px';
-  pct.textContent='0%';
-  wrap.appendChild(bar); wrap.appendChild(pct);
-  panel.appendChild(lab); panel.appendChild(wrap);
-  after && after.parentNode.insertBefore(panel, after.nextSibling);
+  panel = document.createElement('div');
+  panel.id = 'progressPanel';
+  panel.className = 'panel thinking-panel';
+  const lab = document.createElement('div');
+  lab.id = 'progressLabel';
+  lab.className = 'thinking-text';
+  lab.textContent = 'Thinking...';
+  panel.appendChild(lab);
+  if (after && after.parentNode){
+    after.parentNode.insertBefore(panel, after.nextSibling);
+  } else {
+    document.body.appendChild(panel);
+  }
   return panel;
 }
-function showProgress(total, label){
+function showProgress(total){
   const panel = ensureProgressPanel();
-  const bar = document.getElementById('progressBar');
-  const lab = document.getElementById('progressLabel');
-  const pct = document.getElementById('progressPct');
-  panel.style.display = 'block';
-  bar.style.width = '0%';
-  pct.textContent = '0% (0/' + total + ')';
-  lab.textContent = (label||'Working…') + ' 0/' + total;
-  panel.dataset.total = String(total);
+  panel.style.display = 'flex';
+  panel.dataset.total = String(Math.max(1, total || 1));
   panel.dataset.done = '0';
+  lastHeatScore = 0;
+  restartThinkingAnimation('Thinking');
 }
-function updateProgress(done, extra){
-  const panel = document.getElementById('progressPanel'); if (!panel) return;
-  const bar = document.getElementById('progressBar');
-  const lab = document.getElementById('progressLabel');
-  const pct = document.getElementById('progressPct');
-  const total = Math.max(1, parseInt(panel.dataset.total||'1'));
-  const pc = Math.max(0, Math.min(100, Math.floor(done*100/total)));
-  bar.style.width = pc + '%';
-  pct.textContent = pc + '% (' + done + '/' + total + ')';
-  lab.textContent = (extra? extra + ' — ': '') + done + '/' + total + ' (' + pc + '%)';
-  panel.dataset.done = String(done);
+function updateProgress(done){
+  const panel = document.getElementById('progressPanel');
+  if (!panel) return;
+  panel.dataset.done = String(Math.max(0, done|0));
 }
-function hideProgress(){ const p=document.getElementById('progressPanel'); if (p) p.style.display='none'; }
+function hideProgress(){
+  const panel = document.getElementById('progressPanel');
+  if (panel){
+    panel.style.display = 'none';
+  }
+  stopThinkingAnimation();
+}
 function uiYield(){ return new Promise(r=>setTimeout(r,0)); }
 
 // ===== Unknown alphabet Vigenère solver =====
@@ -2179,7 +2275,7 @@ async function runUnknownAlphabetInline(){
   const isVigMode = (op === 'vig_custom_alpha');
   const autokeyAlgo = currentAutokeyAlgo();
   const autokeyLabel = autokeyAlgoLabel(autokeyAlgo);
-  showProgress(total, isVigMode ? 'Unknown alphabet Vigenère' : `Autokey (${autokeyLabel}) + unknown alphabet`);
+  showProgress(total);
   const results=[];
   const coveragePerM = [];
   for (let kLen=minK; kLen<=maxK; kLen++){
@@ -2210,7 +2306,7 @@ async function runUnknownAlphabetInline(){
         kRaw: sol.k
       });
     }
-    updateProgress(kLen - minK + 1, 'm=' + kLen);
+    updateProgress(kLen - minK + 1);
     if ((kLen - minK) % 1 === 0) await uiYield();
   }
   hideProgress();
@@ -3565,7 +3661,7 @@ try{
       if (SUMMARY) setSummaryMessage(`Running ${modeLabel}…`);
       if (OUT) OUT.textContent = '';
       if (CAND_CNT) CAND_CNT.textContent = '0';
-      showProgress(1, 'Estimating search space…');
+      showProgress(1);
 
       if (uaWorker){ try { uaWorker.terminate(); } catch(e){} }
       uaWorker = makeWorker();
@@ -3587,10 +3683,10 @@ try{
             const totalNum = Math.max(1, data.total|0);
             const currentTotal = parseInt(panel.dataset.total || '0');
             if (!initializedTotal || currentTotal !== totalNum){
-              showProgress(totalNum, data.label || 'Working…');
+              showProgress(totalNum);
               initializedTotal = true;
             }
-            updateProgress(data.done|0, data.label || '');
+            updateProgress(data.done|0);
             return;
           }
           const dfs = data.p && data.p.kind === 'dfs' ? data.p : (kind === 'dfs' ? data : null);
@@ -3600,11 +3696,10 @@ try{
             const panel = ensureProgressPanel();
             const currentTotal = parseInt(panel.dataset.total || '0');
             if (!initializedTotal || currentTotal !== dynTotal){
-              showProgress(dynTotal, `m=${data.m ?? ''} — exploring search space…`);
+              showProgress(dynTotal);
               initializedTotal = true;
             }
-            const label = `m=${data.m ?? '?'}  nodes: ${nodeSeen.toLocaleString()} (continuing…)`;
-            updateProgress(nodeSeen, label);
+            updateProgress(nodeSeen);
             return;
           }
         }
@@ -3717,7 +3812,7 @@ try{
         BRUTE_SUMMARY.textContent = text;
       }
 
-      showProgress(Math.max(1, totalWords), 'Brute forcing wordlist…');
+      showProgress(Math.max(1, totalWords));
 
       if (uaWorker){ try { uaWorker.terminate(); } catch(e){} }
       uaWorker = makeWorker();
@@ -3730,7 +3825,7 @@ try{
         if (kind === 'brute_progress'){
           const total = Math.max(1, data.total|0);
           if (!progressInitialized){
-            showProgress(total, 'Brute forcing wordlist…');
+            showProgress(total);
             progressInitialized = true;
           }
           const done = data.done|0;
@@ -3738,8 +3833,7 @@ try{
           const skipped = data.skipped|0;
           const timedOut = typeof data.timedOut === 'number' ? data.timedOut|0 : 0;
           const processed = typeof data.processed === 'number' ? data.processed|0 : Math.max(done, checked + skipped);
-          const label = data.label || `Processed ${processed.toLocaleString()} / ${total.toLocaleString()} words`;
-          updateProgress(done, label);
+          updateProgress(done);
           if (BRUTE_SUMMARY){
             const timeoutPart = timedOut > 0 ? `, timed out ${timedOut.toLocaleString()}` : '';
             let text = `Processed ${processed.toLocaleString()} / ${total.toLocaleString()} words — checked ${checked.toLocaleString()} (skipped ${skipped.toLocaleString()}${timeoutPart}).`;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Puzzle Decrypter Playground</title>
+  <title>Solve the Secret</title>
   <style>
     :root{
       --bg:#020617;
@@ -360,15 +360,17 @@
 </head>
 <body>
   <header class="hero">
-    <h1>Autokey Puzzle Playground</h1>
-    <p>Crack a mysterious message by guessing the missing letters. Start by pasting your cipher text, sprinkle in the letters you feel confident about, and let the playground test how close you are to a real English solution.</p>
+    <h1>Solve the Secret</h1>
+    <p>Help crack a 10 year unsolved puzzle.</p>
   </header>
 
   <div class="panels">
     <section class="panel" id="setupPanel">
-      <h2>Step 1 · Drop in your cipher</h2>
-      <p class="muted">We keep all punctuation and spacing intact so everything lines up perfectly while you solve.</p>
-      <textarea id="ctext">Rc qipv jhx vld plson fhceuh itp jui gh qhzu dg sq xie dhw. U gbfl lf fluz pcag wrgkv zw, dinyg zw, qge gnvm L fhx.</textarea>
+      <h2>Step 1 · Meet the mystery</h2>
+      <p class="muted">We've loaded a puzzling cipher that keeps all punctuation and spacing intact so everything lines up perfectly while you solve.</p>
+      <div class="hidden-control">
+        <textarea id="ctext">Rc qipv jhx vld plson fhceuh itp jui gh qhzu dg sq xie dhw. U gbfl lf fluz pcag wrgkv zw, dinyg zw, qge gnvm L fhx.</textarea>
+      </div>
 
       <div class="hidden-control">
         <label class="small muted" for="minK">Key length range:</label>

--- a/index.html
+++ b/index.html
@@ -6,17 +6,17 @@
   <title>Solve the Secret</title>
   <style>
     :root{
-      --bg:#020617;
-      --panel:#0f172a;
-      --muted:#94a3b8;
-      --ink:#f8fafc;
-      --accent:#38bdf8;
-      --accent-soft:rgba(56,189,248,0.18);
-      --input-bg:#0b1220;
-      --input-ink:#f8fafc;
-      --input-bd:#1e293b;
-      --hot:#f97316;
-      --cold:#38bdf8;
+      --bg:#f7fcee;
+      --panel:rgba(255,255,255,0.92);
+      --muted:#5f6d7a;
+      --ink:#1f2933;
+      --accent:#f472b6;
+      --accent-soft:rgba(244,114,182,0.22);
+      --input-bg:#fff7f9;
+      --input-ink:#1f2933;
+      --input-bd:#fbcfe8;
+      --hot:#fb7185;
+      --cold:#bbf7d0;
       font-family:'Nunito', 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
     }
     *, *::before, *::after { box-sizing:border-box; }
@@ -26,10 +26,10 @@
       justify-content:center;
       text-align:center;
       min-height:96px;
-      background:rgba(8,17,35,0.85);
+      background:rgba(255,255,255,0.85);
       border-radius:18px;
-      border:1px solid rgba(56,189,248,0.14);
-      box-shadow:inset 0 0 0 1px rgba(15,23,42,0.4);
+      border:1px solid rgba(251,207,232,0.6);
+      box-shadow:0 18px 38px rgba(180,206,145,0.35);
       padding:18px;
     }
     .thinking-text {
@@ -38,12 +38,12 @@
       letter-spacing:0.12em;
       text-transform:uppercase;
       color:var(--accent);
-      text-shadow:0 0 26px rgba(56,189,248,0.35);
+      text-shadow:0 0 16px rgba(244,114,182,0.35);
     }
     body {
       margin: 0;
       min-height: 100vh;
-      background: radial-gradient(circle at top left, #172554 0%, #020617 55%, #01030f 100%);
+      background: radial-gradient(circle at top left, #fef3c7 0%, #f7fcee 55%, #fde4f2 100%);
       color: var(--ink);
       padding: 32px 18px 280px;
       box-sizing: border-box;
@@ -74,7 +74,7 @@
     .panel {
       background: var(--panel);
       border-radius: 18px;
-      box-shadow: 0 28px 60px rgba(2,6,23,0.55);
+      box-shadow: 0 28px 60px rgba(214,232,200,0.6);
       padding: 24px;
       position: relative;
       overflow: hidden;
@@ -87,7 +87,7 @@
       background:var(--accent-soft);
       border-radius:50%;
       filter:blur(0px);
-      opacity:.4;
+      opacity:.6;
       pointer-events:none;
     }
     .floating-panel {
@@ -96,9 +96,9 @@
       transform:translateX(-50%);
       bottom:calc(32px + env(safe-area-inset-bottom, 0px));
       width:min(520px, calc(100% - 40px));
-      background:rgba(15,23,42,0.95);
+      background:rgba(255,255,255,0.95);
       border-radius:22px;
-      box-shadow:0 38px 80px rgba(2,6,23,0.75), 0 0 0 1px rgba(56,189,248,0.12);
+      box-shadow:0 28px 70px rgba(214,232,200,0.75), 0 0 0 1px rgba(251,207,232,0.4);
       padding:26px 28px 28px;
       display:flex;
       flex-direction:column;
@@ -127,12 +127,12 @@
       color:var(--input-ink);
       border:2px solid var(--input-bd);
       transition:border-color .2s ease, box-shadow .2s ease;
-      box-shadow:0 12px 26px rgba(8,17,35,0.65);
+      box-shadow:0 12px 26px rgba(216,232,182,0.6);
     }
     textarea:focus {
       outline:none;
       border-color:var(--accent);
-      box-shadow:0 14px 34px rgba(56,189,248,0.35);
+      box-shadow:0 14px 34px rgba(244,114,182,0.35);
     }
     .grid {
       display:flex;
@@ -141,11 +141,16 @@
       margin-top:16px;
       padding:18px;
       border-radius:16px;
-      background:linear-gradient(145deg, rgba(56,189,248,0.08), rgba(15,118,110,0.08));
-      border:1px solid rgba(148,163,184,0.12);
+      background:linear-gradient(145deg, rgba(187,247,208,0.4), rgba(252,231,243,0.35));
+      border:1px solid rgba(251,207,232,0.65);
       align-items:flex-start;
       overflow-x:auto;
       -webkit-overflow-scrolling:touch;
+    }
+    html.is-ios-safari .grid {
+      display:block;
+      overflow-x:visible;
+      padding-right:22px;
     }
     .word {
       display:flex;
@@ -153,15 +158,27 @@
       flex:0 0 auto;
       gap:8px;
     }
+    html.is-ios-safari .word {
+      display:inline-flex;
+      margin:0 18px 12px 0;
+    }
     .word-gap {
       flex:0 0 26px;
       height:1px;
       pointer-events:none;
     }
+    html.is-ios-safari .word-gap {
+      display:inline-block;
+      width:26px;
+    }
     .line-break {
       flex-basis:100%;
       height:0;
       pointer-events:none;
+    }
+    html.is-ios-safari .line-break {
+      display:block;
+      width:100%;
     }
     .cell {
       width:38px;
@@ -172,17 +189,21 @@
       align-items:center;
       gap:6px;
     }
+    html.is-ios-safari .cell {
+      width:40px;
+      margin-bottom:6px;
+    }
     .char {
       display:block;
       padding:8px 0;
-      background:#1e293b;
+      background:#fef9c3;
       border-radius:12px;
       font-weight:700;
       border:2px solid transparent;
       width:100%;
       box-sizing:border-box;
-      color:var(--accent);
-      box-shadow:0 10px 22px rgba(2,6,23,0.55);
+      color:#047857;
+      box-shadow:0 10px 22px rgba(214,232,200,0.6);
     }
     .cell.selecting { cursor:pointer }
     .cell.selected .char { border-color:var(--accent); }
@@ -191,18 +212,29 @@
       text-align:center;
       border-radius:12px;
       padding:10px 0;
-      background:#1e293b;
+      background:#ecfccb;
       color:var(--input-ink);
-      border:2px solid rgba(56,189,248,0.35);
+      border:2px solid rgba(190,242,100,0.8);
       font-weight:800;
       box-sizing:border-box;
       font-size:20px;
       min-height:44px;
       transition:border-color .2s ease, box-shadow .2s ease;
-      box-shadow:0 10px 24px rgba(8,17,35,0.55);
+      box-shadow:0 10px 24px rgba(214,232,200,0.7);
+      -webkit-appearance:none;
+      appearance:none;
+      background-clip:padding-box;
     }
-    input.cribin:focus { outline:none; border-color:var(--accent); box-shadow:0 16px 36px rgba(56,189,248,0.38); }
-    input.cribin[disabled]{ opacity:.35; cursor:not-allowed; background:rgba(15,23,42,0.9); box-shadow:none }
+    html.is-ios-safari input.cribin {
+      min-height:32px;
+      font-size:18px;
+    }
+    input.cribin:focus {
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:0 16px 36px rgba(244,114,182,0.35);
+    }
+    input.cribin[disabled]{ opacity:.35; cursor:not-allowed; background:rgba(255,255,255,0.6); box-shadow:none; border-color:rgba(190,242,100,0.4); }
     .controls {
       display:flex;
       gap:12px;
@@ -219,20 +251,20 @@
       cursor:pointer;
       transition:transform .15s ease, box-shadow .2s ease;
       background:var(--accent);
-      color:#05132c;
-      box-shadow:0 18px 34px rgba(56,189,248,0.28);
+      color:#fff8f1;
+      box-shadow:0 18px 34px rgba(244,114,182,0.32);
     }
     .controls button.secondary {
-      background:rgba(15,23,42,0.9);
+      background:rgba(255,255,255,0.9);
       color:var(--muted);
-      box-shadow:0 12px 28px rgba(2,6,23,0.55);
-      border:1px solid rgba(148,163,184,0.18);
+      box-shadow:0 12px 28px rgba(214,232,200,0.55);
+      border:1px solid rgba(190,242,100,0.4);
     }
-    .controls button:hover { transform:translateY(-1px); box-shadow:0 22px 40px rgba(56,189,248,0.35); }
-    .controls button.secondary:hover { box-shadow:0 16px 30px rgba(2,6,23,0.7); }
+    .controls button:hover { transform:translateY(-1px); box-shadow:0 22px 40px rgba(244,114,182,0.4); }
+    .controls button.secondary:hover { box-shadow:0 16px 30px rgba(214,232,200,0.65); }
     button:disabled { opacity:.45; cursor:not-allowed; box-shadow:none; transform:none }
     pre {
-      background:rgba(15,23,42,0.85);
+      background:rgba(255,255,255,0.9);
       padding:18px;
       border-radius:16px;
       overflow:auto;
@@ -240,7 +272,7 @@
       font-size:16px;
       line-height:1.6;
       color:var(--ink);
-      box-shadow:inset 0 0 0 1px rgba(56,189,248,0.12);
+      box-shadow:inset 0 0 0 1px rgba(251,207,232,0.4);
     }
     .muted { color:var(--muted); }
     .legend { display:none }
@@ -252,28 +284,28 @@
       transition:color .2s ease, transform .2s ease;
     }
     .summary-text.no-result {
-      color:var(--accent);
+      color:#15803d;
       font-size:20px;
       font-weight:800;
       letter-spacing:0.01em;
-      text-shadow:0 0 20px rgba(56,189,248,0.35);
+      text-shadow:0 0 20px rgba(190,242,100,0.5);
     }
     .heat-meter { margin-top:18px; }
     .heat-track {
       position:relative;
       height:20px;
-      background:rgba(15,23,42,0.9);
-      border:1px solid rgba(56,189,248,0.25);
+      background:rgba(255,255,255,0.9);
+      border:1px solid rgba(190,242,100,0.6);
       border-radius:999px;
       overflow:hidden;
-      box-shadow:0 14px 30px rgba(2,6,23,0.65);
+      box-shadow:0 14px 30px rgba(214,232,200,0.65);
     }
     .heat-fill {
       position:absolute;
       top:0;left:0;height:100%;
       width:0%;
-      background:linear-gradient(90deg,var(--cold) 0%, #60a5fa 25%, #a855f7 60%, var(--hot) 100%);
-      box-shadow:0 0 18px rgba(249,115,22,0.45);
+      background:linear-gradient(90deg,var(--cold) 0%, #fef08a 30%, #f9a8d4 65%, var(--hot) 100%);
+      box-shadow:0 0 18px rgba(251,113,133,0.45);
       transition:width .35s ease, box-shadow .35s ease;
     }
     .heat-labels {
@@ -285,7 +317,7 @@
     }
     .hidden-control { display:none !important; }
     #progressPanel { display:none; width:100%; }
-    #progressLabel { font-weight:800; font-size:22px; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); text-shadow:0 0 26px rgba(56,189,248,0.35); }
+    #progressLabel { font-weight:800; font-size:22px; letter-spacing:0.12em; text-transform:uppercase; color:var(--accent); text-shadow:0 0 26px rgba(244,114,182,0.35); }
 
     .confetti-container {
       position:fixed;
@@ -316,7 +348,7 @@
       .grid { justify-content:center; }
       .cell { width:40px; }
       .char { padding:6px 0; font-size:14px; }
-      input.cribin { min-height:40px; padding:8px 0; font-size:18px; }
+      input.cribin { min-height:34px; padding:6px 0; font-size:16px; }
       textarea { min-height:140px; }
       .floating-panel {
         width:calc(100% - 24px);
@@ -333,7 +365,7 @@
       .grid { gap:12px 10px; }
       .cell { width:34px; }
       .char { padding:5px 0; font-size:13px; }
-      input.cribin { min-height:36px; padding:6px 0; font-size:16px; }
+      input.cribin { min-height:30px; padding:5px 0; font-size:15px; }
       textarea { min-height:160px; }
       .floating-panel { bottom:calc(18px + env(safe-area-inset-bottom, 0px)); }
     }
@@ -460,12 +492,25 @@ const sanitize = s => s.toUpperCase().replace(/[^A-Z]/g,'');
 
 let wordlist = [];
 
-const CONFETTI_COLORS = ['#38bdf8', '#f97316', '#a855f7', '#22d3ee', '#facc15'];
+const CONFETTI_COLORS = ['#bbf7d0', '#fef08a', '#fbcfe8', '#bef264', '#f9a8d4'];
 const THINKING_STATES = ['.', '..', '...'];
 let confettiCooling = false;
 let lastHeatScore = 0;
 let thinkingInterval = null;
 let thinkingIndex = 0;
+
+function isIOSSafari(){
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  const isIOS = /iPad|iPhone|iPod/.test(ua);
+  const isSafari = /Safari/i.test(ua) && !/CriOS|FxiOS|OPiOS|EdgiOS/.test(ua);
+  return isIOS && isSafari;
+}
+
+const IOS_SAFARI = isIOSSafari();
+if (IOS_SAFARI && typeof document !== 'undefined'){
+  document.documentElement.classList.add('is-ios-safari');
+}
 
 function shouldDeferAutoFocus(){
   if (typeof window === 'undefined') return false;
@@ -689,7 +734,7 @@ function updateHeatMeter(stats){
   heatFill.style.opacity = '1';
   const glow = Math.max(12, 12 + pct * 0.2);
   const glowAlpha = Math.min(0.75, 0.25 + pct / 200);
-  heatFill.style.boxShadow = pct > 0 ? `0 0 ${glow}px rgba(249,115,22,${glowAlpha.toFixed(2)})` : 'none';
+  heatFill.style.boxShadow = pct > 0 ? `0 0 ${glow}px rgba(251,113,133,${glowAlpha.toFixed(2)})` : 'none';
   heatFill.setAttribute('aria-valuenow', String(pct));
   heatFill.setAttribute('aria-valuemin', '0');
   heatFill.setAttribute('aria-valuemax', '100');

--- a/index.html
+++ b/index.html
@@ -107,6 +107,51 @@
       backdrop-filter:blur(12px);
       -webkit-backdrop-filter:blur(12px);
     }
+    .floating-panel.collapsed {
+      padding-bottom:18px;
+      gap:14px;
+    }
+    .floating-header {
+      display:flex;
+      align-items:flex-start;
+      justify-content:space-between;
+      gap:14px;
+    }
+    .floating-title {
+      flex:1;
+      display:flex;
+      flex-direction:column;
+      gap:8px;
+    }
+    .results-toggle {
+      display:none;
+      align-items:center;
+      justify-content:center;
+      padding:8px 16px;
+      border-radius:999px;
+      border:1px solid rgba(244,114,182,0.35);
+      background:rgba(244,114,182,0.18);
+      color:var(--accent);
+      font-weight:700;
+      cursor:pointer;
+      box-shadow:0 12px 24px rgba(244,114,182,0.22);
+      transition:background .2s ease, box-shadow .2s ease, transform .15s ease;
+    }
+    .results-toggle:hover {
+      background:rgba(244,114,182,0.28);
+      box-shadow:0 18px 32px rgba(244,114,182,0.28);
+    }
+    .results-toggle:active {
+      transform:translateY(1px);
+    }
+    .floating-body {
+      display:flex;
+      flex-direction:column;
+      gap:18px;
+    }
+    .floating-panel.collapsed .floating-body {
+      display:none;
+    }
     #results {
       max-height:min(420px, 70vh);
       overflow-y:auto;
@@ -356,6 +401,9 @@
         padding:22px 22px 24px;
         border-radius:20px;
       }
+      .floating-header { flex-direction:column; align-items:flex-start; gap:12px; }
+      .results-toggle { display:inline-flex; align-self:flex-end; }
+      .floating-panel.collapsed { padding:18px 18px 20px; }
       #results { max-height:65vh; }
     }
 
@@ -438,15 +486,22 @@
     </section>
 
     <section class="floating-panel" id="results">
-      <h2>Step 3 · See how hot your guess is</h2>
-      <div id="summary" class="summary-text muted">No test run yet — add a few guesses to start!</div>
-      <div class="heat-meter">
-        <div class="heat-track">
-          <div id="heatFill" class="heat-fill" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
+      <div class="floating-header">
+        <div class="floating-title">
+          <h2>Step 3 · See how hot your guess is</h2>
+          <div id="summary" class="summary-text muted">No test run yet — add a few guesses to start!</div>
         </div>
-        <div class="heat-labels"><span>Cold</span><span>Hot!</span></div>
+        <button type="button" id="resultsToggle" class="results-toggle" aria-expanded="true" aria-controls="resultsBody">Hide details</button>
       </div>
-      <pre id="out"></pre>
+      <div class="floating-body" id="resultsBody">
+        <div class="heat-meter">
+          <div class="heat-track">
+            <div id="heatFill" class="heat-fill" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
+          </div>
+          <div class="heat-labels"><span>Cold</span><span>Hot!</span></div>
+        </div>
+        <pre id="out"></pre>
+      </div>
     </section>
 
     <section class="panel hidden-control" id="wordlistPanel">
@@ -498,6 +553,11 @@ let confettiCooling = false;
 let lastHeatScore = 0;
 let thinkingInterval = null;
 let thinkingIndex = 0;
+const MOBILE_RESULTS_QUERY = '(max-width: 720px)';
+let resultsCollapseMedia = (typeof window !== 'undefined' && typeof window.matchMedia === 'function')
+  ? window.matchMedia(MOBILE_RESULTS_QUERY)
+  : null;
+let resultsCollapsed = resultsCollapseMedia ? resultsCollapseMedia.matches : false;
 
 function isIOSSafari(){
   if (typeof navigator === 'undefined') return false;
@@ -520,6 +580,74 @@ function shouldDeferAutoFocus(){
   const ua = nav && nav.userAgent ? nav.userAgent : '';
   const isiOS = /iPad|iPhone|iPod/.test(ua);
   return hasTouch || isiOS;
+}
+
+function isMobileResultsView(){
+  if (resultsCollapseMedia) return resultsCollapseMedia.matches;
+  if (typeof window === 'undefined') return false;
+  return window.innerWidth <= 720;
+}
+
+function updateResultsToggleVisibility(){
+  const toggle = document.getElementById('resultsToggle');
+  if (!toggle) return;
+  const mobile = isMobileResultsView();
+  toggle.style.display = mobile ? 'inline-flex' : 'none';
+  if (!mobile){
+    toggle.setAttribute('aria-expanded', 'true');
+    toggle.textContent = 'Hide details';
+  }
+}
+
+function setResultsCollapsed(collapsed){
+  const panel = document.getElementById('results');
+  const toggle = document.getElementById('resultsToggle');
+  const mobile = isMobileResultsView();
+  const desired = !!collapsed;
+  resultsCollapsed = desired;
+  const shouldCollapse = desired && mobile;
+  if (panel){
+    panel.classList.toggle('collapsed', shouldCollapse);
+  }
+  if (toggle){
+    if (mobile){
+      toggle.textContent = shouldCollapse ? 'Show details' : 'Hide details';
+      toggle.setAttribute('aria-expanded', String(!shouldCollapse));
+    } else {
+      toggle.textContent = 'Hide details';
+      toggle.setAttribute('aria-expanded', 'true');
+    }
+  }
+}
+
+function handleResultsMediaChange(){
+  updateResultsToggleVisibility();
+  setResultsCollapsed(resultsCollapsed);
+}
+
+function initResultsPanel(){
+  if (!resultsCollapseMedia && typeof window !== 'undefined' && typeof window.matchMedia === 'function'){
+    resultsCollapseMedia = window.matchMedia(MOBILE_RESULTS_QUERY);
+  }
+  updateResultsToggleVisibility();
+  resultsCollapsed = isMobileResultsView();
+  setResultsCollapsed(resultsCollapsed);
+  const toggle = document.getElementById('resultsToggle');
+  if (toggle){
+    toggle.addEventListener('click', () => {
+      setResultsCollapsed(!resultsCollapsed);
+    });
+  }
+  const listener = () => handleResultsMediaChange();
+  if (resultsCollapseMedia){
+    if (typeof resultsCollapseMedia.addEventListener === 'function'){
+      resultsCollapseMedia.addEventListener('change', listener);
+    } else if (typeof resultsCollapseMedia.addListener === 'function'){
+      resultsCollapseMedia.addListener(listener);
+    }
+  } else if (typeof window !== 'undefined'){
+    window.addEventListener('resize', listener);
+  }
 }
 
 function triggerConfetti(){
@@ -592,6 +720,9 @@ function setSummaryMessage(text, options){
   if (!summary) return;
   summary.textContent = text;
   const opts = options || {};
+  if (opts.forceExpand){
+    setResultsCollapsed(false);
+  }
   const isNoResult = !!opts.noResult;
   summary.classList.toggle('no-result', isNoResult);
   if (isNoResult){
@@ -2550,6 +2681,7 @@ try{
     }
     updateAutokeyAlgoVisibility();
     resetHeatMeter();
+    initResultsPanel();
 
     let uaWorker = null;
     let currentJob = null;
@@ -3819,8 +3951,7 @@ try{
           else if (pct >= 40) mood = '✨ Warming up — a few tweaks might crack it.';
           else if (pct > 0) mood = '🧊 Still chilly. Try sprinkling in more crib letters.';
           else mood = 'Add a few more confident letters so the meter can take a proper reading.';
-          const variantLabel = autokeyAlgoLabel(algo);
-          setSummaryMessage(`Key length ${best.keyLength} (${variantLabel}): ${mood} (${pct}% hot)`);
+          setSummaryMessage(`Key length ${best.keyLength}: ${mood} (${pct}% hot)`, { forceExpand: true });
         }
       };
 
@@ -3859,14 +3990,13 @@ try{
 
         if (CAND_CNT) CAND_CNT.textContent = '0';
 
-        const variantLabel = autokeyAlgoLabel(currentAlgo);
         const message = nextAlgoIndex === 0
-          ? `Thinking through the ${variantLabel} autokey twist…`
-          : `No clear text yet — trying the ${variantLabel} autokey twist next…`;
+          ? 'Thinking through the puzzle…'
+          : 'No clear text yet — trying another approach…';
         if (SUMMARY) setSummaryMessage(message);
 
         showProgress(1);
-        restartThinkingAnimation(`Thinking — ${variantLabel}`);
+        restartThinkingAnimation('Thinking');
 
         if (uaWorker){ try { uaWorker.terminate(); } catch(e){} }
         uaWorker = makeWorker();
@@ -3887,7 +4017,7 @@ try{
               const currentTotal = parseInt(panel.dataset.total || '0');
               if (!initializedTotal || currentTotal !== totalNum){
                 showProgress(totalNum);
-                restartThinkingAnimation(`Thinking — ${variantLabel}`);
+                restartThinkingAnimation('Thinking');
                 initializedTotal = true;
               }
               updateProgress(data.done|0);
@@ -3901,7 +4031,7 @@ try{
               const currentTotal = parseInt(panel.dataset.total || '0');
               if (!initializedTotal || currentTotal !== dynTotal){
                 showProgress(dynTotal);
-                restartThinkingAnimation(`Thinking — ${variantLabel}`);
+                restartThinkingAnimation('Thinking');
                 initializedTotal = true;
               }
               updateProgress(nodeSeen);
@@ -3929,8 +4059,7 @@ try{
             }
 
             if (SUMMARY){
-              const peekLabel = autokeyAlgoLabel(queue[0]);
-              setSummaryMessage(`Still frosty — switching to the ${peekLabel} autokey flavor…`);
+              setSummaryMessage('Still frosty — trying another approach…');
             }
 
             launchNext(nextAlgoIndex + 1);

--- a/index.html
+++ b/index.html
@@ -3,126 +3,330 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Cipher Crib Tester</title>
+  <title>Puzzle Decrypter Playground</title>
   <style>
-#progressBar{background:#60a5fa;height:100%;width:0%}
+#progressBar{background:#f97316;height:100%;width:0%;transition:width .3s ease}
 
-    :root{--bg:#0f1724;--panel:#0b1220;--muted:#9fb1c9;--ink:#e6eef8;--accent:#60a5fa;--input-bg:#f8fafc;--input-ink:#0f1724;--input-bd:#b6c2d9}
-    body { font-family: Inter, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial; margin: 18px; background:var(--bg); color:var(--ink) }
-    h1 { font-size: 18px; margin:0 0 8px }
-    h2 { font-size: 14px; margin:0 0 8px }
-    .panel { background:var(--panel); border:1px solid rgba(255,255,255,0.06); padding:12px; border-radius:8px; margin-bottom:12px }
-    textarea { width:100%; height:90px; font-family: monospace; font-size:14px; padding:8px; border-radius:6px; background:#071022; color:#dbeafe; border:1px solid rgba(255,255,255,0.08) }
-    .grid { display:flex; gap:6px; flex-wrap:wrap; margin-top:10px }
-    .cell { width:34px; text-align:center; position:relative; display:flex; flex-direction:column; align-items:center; gap:4px }
+    :root{
+      --bg:#f3f4ff;
+      --panel:#ffffff;
+      --muted:#5b6780;
+      --ink:#131728;
+      --accent:#6366f1;
+      --accent-soft:rgba(99,102,241,0.15);
+      --input-bg:#f4f5ff;
+      --input-ink:#131728;
+      --input-bd:#d7dcf9;
+      --hot:#f97316;
+      --cold:#38bdf8;
+      font-family:'Nunito', 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: radial-gradient(circle at top left, #eef1ff, #f3f4ff 55%, #e8edff 100%);
+      color: var(--ink);
+      padding: 32px 18px 54px;
+      box-sizing: border-box;
+    }
+    h1 { font-size: 28px; margin:0 0 8px; font-weight:800; letter-spacing:-0.01em }
+    h2 { font-size: 18px; margin:0 0 12px; font-weight:700 }
+    p { margin:0 }
+    .hero {
+      max-width: 900px;
+      margin: 0 auto 24px;
+      text-align: center;
+    }
+    .hero p {
+      color: var(--muted);
+      font-size: 16px;
+      line-height: 1.5;
+    }
+    .panels {
+      max-width: 960px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+    .panel {
+      background: var(--panel);
+      border-radius: 18px;
+      box-shadow: 0 20px 45px rgba(15,23,42,0.08);
+      padding: 24px;
+      position: relative;
+      overflow: hidden;
+    }
+    .panel::before{
+      content:"";
+      position:absolute;
+      inset:-120px -120px auto auto;
+      width:220px;height:220px;
+      background:var(--accent-soft);
+      border-radius:50%;
+      filter:blur(0px);
+      opacity:.4;
+      pointer-events:none;
+    }
+    textarea {
+      width:100%;
+      min-height:120px;
+      font-family: 'Fira Code', monospace;
+      font-size:15px;
+      padding:16px;
+      border-radius:14px;
+      background:var(--input-bg);
+      color:var(--input-ink);
+      border:2px solid transparent;
+      transition:border-color .2s ease, box-shadow .2s ease;
+      box-shadow:0 6px 18px rgba(99,102,241,0.08);
+    }
+    textarea:focus {
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:0 12px 30px rgba(99,102,241,0.16);
+    }
+    .grid {
+      display:flex;
+      gap:8px;
+      flex-wrap:wrap;
+      margin-top:16px;
+      padding:18px;
+      border-radius:16px;
+      background:linear-gradient(145deg, rgba(99,102,241,0.08), rgba(56,189,248,0.08));
+    }
+    .cell {
+      width:38px;
+      text-align:center;
+      position:relative;
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      gap:6px;
+    }
+    .char {
+      display:block;
+      padding:8px 0;
+      background:#ffffff;
+      border-radius:12px;
+      font-weight:700;
+      border:2px solid transparent;
+      width:100%;
+      box-sizing:border-box;
+      color:var(--accent);
+      box-shadow:0 6px 15px rgba(148,163,184,0.28);
+    }
     .cell.selecting { cursor:pointer }
-    .cell.selected .char { background:#1e3a5f; border:2px solid var(--accent); }
-    .char { display:block; padding:6px 4px; background:#081426; border-radius:6px; font-weight:700; border:2px solid transparent; width:100%; box-sizing:border-box }
-    input.cribin { width:100%; text-align:center; border-radius:6px; padding:8px 4px; background:var(--input-bg); color:var(--input-ink); border:1px solid var(--input-bd); font-weight:700; box-sizing:border-box; font-size:18px; min-height:36px }
-    input.cribin:focus { outline:2px solid var(--accent); outline-offset:0 }
-    input.cribin[disabled]{ opacity:.35; cursor:not-allowed }
-    .controls { display:flex; gap:8px; align-items:center; margin-top:10px; flex-wrap:wrap }
-    select,input[type=number],input[type=file],button,.checkbox-row { padding:8px 10px; border-radius:6px; background:#052033; color:#dbeafe; border:1px solid rgba(255,255,255,0.08) }
-    .checkbox-row{ display:flex; gap:8px; align-items:center }
-    button { cursor:pointer }
-    button:hover { background:#063a5a }
-    button.active { background:#1e3a5f; border-color:var(--accent) }
-    pre { background:#071426; padding:10px; border-radius:6px; overflow:auto; white-space:pre-wrap }
-    .ok { color:#8ef8b0 }
-    .bad { color:#ff9b9b }
-    .muted { color:var(--muted) }
-    .legend { display:flex; gap:14px; margin-top:8px; flex-wrap:wrap }
-    .small { font-size:12px }
-    .row { display:flex; gap:10px; align-items:center; flex-wrap:wrap }
-    .result-item { background:#081426; padding:8px; margin:8px 0; border-radius:6px; border-left:3px solid var(--accent) }
-    .result-item.top { border-left-color:#8ef8b0 }
-    .score { color:var(--accent); font-weight:700 }
-    .selection-info { background:#081426; padding:8px; border-radius:6px; margin-top:8px; display:none }
-    .selection-info.active { display:block }
-    @media (max-width: 640px) {
-      .grid { gap:4px }
-      .cell { width:42px }
-      .char { font-size:16px; padding:6px 3px }
-      input.cribin { min-height:40px; font-size:20px; padding:10px 4px }
+    .cell.selected .char { border-color:var(--accent); }
+    input.cribin {
+      width:100%;
+      text-align:center;
+      border-radius:12px;
+      padding:10px 0;
+      background:#fff;
+      color:var(--input-ink);
+      border:2px solid rgba(99,102,241,0.25);
+      font-weight:800;
+      box-sizing:border-box;
+      font-size:20px;
+      min-height:44px;
+      transition:border-color .2s ease, box-shadow .2s ease;
+      box-shadow:0 6px 15px rgba(99,102,241,0.08);
+    }
+    input.cribin:focus { outline:none; border-color:var(--accent); box-shadow:0 12px 30px rgba(99,102,241,0.16); }
+    input.cribin[disabled]{ opacity:.35; cursor:not-allowed; background:rgba(255,255,255,0.7); box-shadow:none }
+    .controls {
+      display:flex;
+      gap:12px;
+      align-items:center;
+      margin-top:18px;
+      flex-wrap:wrap;
+      justify-content:flex-end;
+    }
+    .controls button {
+      padding:12px 22px;
+      border-radius:999px;
+      border:none;
+      font-weight:700;
+      cursor:pointer;
+      transition:transform .15s ease, box-shadow .2s ease;
+      background:var(--accent);
+      color:#fff;
+      box-shadow:0 14px 30px rgba(99,102,241,0.28);
+    }
+    .controls button.secondary {
+      background:rgba(99,102,241,0.1);
+      color:var(--accent);
+      box-shadow:none;
+    }
+    .controls button:hover { transform:translateY(-1px); box-shadow:0 18px 36px rgba(99,102,241,0.28); }
+    .controls button.secondary:hover { box-shadow:0 8px 20px rgba(99,102,241,0.2); }
+    button:disabled { opacity:.45; cursor:not-allowed; box-shadow:none; transform:none }
+    pre {
+      background:rgba(99,102,241,0.07);
+      padding:18px;
+      border-radius:16px;
+      overflow:auto;
+      white-space:pre-wrap;
+      font-size:16px;
+      line-height:1.6;
+      color:var(--ink);
+      box-shadow:inset 0 0 0 1px rgba(99,102,241,0.12);
+    }
+    .muted { color:var(--muted); }
+    .legend { display:none }
+    .small { font-size:13px }
+    .heat-meter { margin-top:18px; }
+    .heat-track {
+      position:relative;
+      height:20px;
+      background:linear-gradient(90deg,var(--cold),#38c0f8,#60a5fa,#a855f7,var(--hot));
+      border-radius:999px;
+      overflow:hidden;
+      box-shadow:0 6px 14px rgba(99,102,241,0.18);
+    }
+    .heat-fill {
+      position:absolute;
+      top:0;left:0;height:100%;
+      width:0%;
+      background:rgba(255,255,255,0.65);
+      mix-blend-mode:overlay;
+      transition:width .35s ease;
+    }
+    .heat-labels {
+      margin-top:6px;
+      display:flex;
+      justify-content:space-between;
+      font-weight:600;
+      color:var(--muted);
+    }
+    .stat-chips {
+      display:flex;
+      gap:12px;
+      flex-wrap:wrap;
+      margin-top:14px;
+    }
+    .chip {
+      background:rgba(99,102,241,0.12);
+      color:var(--accent);
+      padding:8px 14px;
+      border-radius:999px;
+      font-weight:700;
+      font-size:13px;
+    }
+    .hidden-control { display:none !important; }
+    #progressWrap {
+      display:none;
+      margin-top:14px;
+      background:rgba(99,102,241,0.1);
+      border-radius:999px;
+      height:18px;
+      overflow:hidden;
+    }
+    #progressLabel { margin-top:8px; font-weight:600; color:var(--muted); }
+    #progressInner { height:100%; background:linear-gradient(90deg, var(--cold), var(--accent)); width:0%; transition:width .3s ease; }
+    @media (max-width: 720px) {
+      body { padding:24px 16px; }
+      .panel { padding:20px; }
+      .grid { justify-content:center; }
+      .cell { width:44px; }
+      textarea { min-height:140px; }
     }
   </style>
 </head>
 <body>
-  <h1>Cipher Crib Tester — Vigenère / MAS+Vig</h1>
+  <header class="hero">
+    <h1>Autokey Puzzle Playground</h1>
+    <p>Crack a mysterious message by guessing the missing letters. Start by pasting your cipher text, sprinkle in the letters you feel confident about, and let the playground test how close you are to a real English solution.</p>
+  </header>
 
-  <div class="panel">
-    <div class="small muted">Paste your ciphertext (punctuation/spaces kept for alignment). Type tentative plaintext letters under <em>letter</em> positions only (non-letters are disabled).</div>
-    <textarea id="ctext">Rc qipv jhx vld plson fhceuh itp jui gh qhzu dg sq xie dhw. U gbfl lf fluz pcag wrgkv zw, dinyg zw, qge gnvm L fhx.</textarea>
-    <div class="row" style="margin-top:10px">
-      <label class="small muted">Key length range:</label>
-      <input id="minK" type="number" min="1" value="1" style="width:72px" />
-      <input id="maxK" type="number" min="1" value="12" style="width:72px" />
-      <label class="small muted">Operation:</label>
-      <select id="op">
-        <option value="vigenere">Vigenère (C = P + K mod26)</option>
-        <option value="vig_sub">Vigenère + unknown substitution (pre‑sub on plaintext)</option>
-        <option value="vig_sub_post">Vigenère + unknown substitution (post‑sub on ciphertext)</option>
-        <option value="vig_custom_alpha">Vigenère with unknown alphabet (shared custom order)</option>
-        <option value="autokey_custom_alpha">Autokey with unknown alphabet (shared custom order)</option>
-      </select>
-      <label id="autokeyAlgoLabel" class="small muted" style="display:none">Autokey variant:</label>
-      <select id="autokeyAlgo" style="display:none">
-        <option value="vigenere">Vigenère-style (C = P + K)</option>
-        <option value="beaufort">Beaufort (C = K − P)</option>
-        <option value="beaufort_variant">Variant Beaufort (C = P − K)</option>
-      </select>
-      <button id="render">Render grid</button>
-      <button id="test">Test cribs</button>
-      <button id="stopSearch" style="display:none">Stop search</button>
-    </div>
-  </div>
+  <div class="panels">
+    <section class="panel" id="setupPanel">
+      <h2>Step 1 · Drop in your cipher</h2>
+      <p class="muted">We keep all punctuation and spacing intact so everything lines up perfectly while you solve.</p>
+      <textarea id="ctext">Rc qipv jhx vld plson fhceuh itp jui gh qhzu dg sq xie dhw. U gbfl lf fluz pcag wrgkv zw, dinyg zw, qge gnvm L fhx.</textarea>
 
-  <div class="panel" id="gridPanel">
-    <div id="grid" class="grid"></div>
-    <div class="legend small">
-      <div><span class="ok">●</span> consistent (no contradiction)</div>
-      <div><span class="bad">●</span> contradiction</div>
-      <div class="muted">Tip: try single-letter cribs (A/I for U/L), repeated pairs (e.g., "zw"), or whole words aligned to punctuation.</div>
-    </div>
-  </div>
+      <div class="hidden-control">
+        <label class="small muted" for="minK">Key length range:</label>
+        <input id="minK" type="number" min="1" value="4" />
+        <input id="maxK" type="number" min="1" value="20" />
+        <label class="small muted" for="op">Operation:</label>
+        <select id="op">
+          <option value="vigenere">Vigenère (C = P + K mod26)</option>
+          <option value="vig_sub">Vigenère + unknown substitution (pre‑sub on plaintext)</option>
+          <option value="vig_sub_post">Vigenère + unknown substitution (post‑sub on ciphertext)</option>
+          <option value="vig_custom_alpha">Vigenère with unknown alphabet (shared custom order)</option>
+          <option value="autokey_custom_alpha" selected>Autokey with unknown alphabet (shared custom order)</option>
+        </select>
+        <label id="autokeyAlgoLabel" class="small muted" for="autokeyAlgo">Autokey variant:</label>
+        <select id="autokeyAlgo">
+          <option value="vigenere">Vigenère-style (C = P + K)</option>
+          <option value="beaufort">Beaufort (C = K − P)</option>
+          <option value="beaufort_variant">Variant Beaufort (C = P − K)</option>
+        </select>
+      </div>
 
-  <div class="panel">
-    <h2>Wordlist Brute Force</h2>
-    <div class="small muted">Upload a wordlist and try all words at a selected position to find the best crib candidates.</div>
-    <div class="row" style="margin-top:10px">
-      <input type="file" id="wordlistFile" accept=".txt" />
-      <button id="selectMode">Select Word Position</button>
-      <label class="small muted">Max results:</label>
-      <input id="maxResults" type="number" min="1" value="20" style="width:72px" />
-            <label class="small muted">Quick trials:</label>
-      <input id="quickTrialsInput" type="number" min="0" value="30" style="width:72px" />
-      <label class="small muted">Trial depth:</label>
-      <input id="trialDepthInput" type="number" min="0" value="3" style="width:72px" />
-      <label class="small muted">Word timeout (ms):</label>
-      <input id="wordTimeoutInput" type="number" min="0" value="1500" style="width:90px" />
-      <label class="checkbox-row small" style="padding:0 6px 0 0">
-        <input type="checkbox" id="bruteBridgeNext" /> Enforce next crib
-      </label>
-      <button id="bruteForce">Brute force cribs</button>
-    </div>
-    <div id="wordlistStatus" class="small muted" style="margin-top:8px">No wordlist loaded</div>
-    <div id="selectionInfo" class="selection-info small">
-      <strong>Selection:</strong> <span id="selectionText">None</span> | 
-      <strong>Position:</strong> <span id="selectionPos">-</span> | 
-      <strong>Length:</strong> <span id="selectionLen">-</span>
-    </div>
-  </div>
+      <div class="controls">
+        <button id="render" class="secondary">Refresh Puzzle</button>
+        <button id="stopSearch" class="secondary" disabled>Stop Search</button>
+        <button id="test">Test My Guess</button>
+      </div>
+    </section>
 
-  <div class="panel" id="results">
-    <h2>Results</h2>
-    <div id="summary" class="small muted">No test run yet</div>
-    <pre id="out"></pre>
-  </div>
+    <section class="panel" id="gridPanel">
+      <h2>Step 2 · Fill in what you know</h2>
+      <p class="muted">Click under each letter and type your guess. We'll only let you edit the spots that are real letters.</p>
+      <div id="grid" class="grid"></div>
+    </section>
 
-  <div class="panel" id="bruteResults" style="display:none">
-    <h2>Brute Force Results</h2>
-    <div id="bruteSummary" class="small muted"></div>
-    <div id="bruteOut"></div>
+    <section class="panel" id="results">
+      <h2>Step 3 · See how hot your guess is</h2>
+      <div id="summary" class="small muted">No test run yet — add a few guesses to start!</div>
+      <div class="heat-meter">
+        <div class="heat-track">
+          <div id="heatFill" class="heat-fill"></div>
+        </div>
+        <div class="heat-labels"><span>Cold</span><span>Hot!</span></div>
+      </div>
+      <div class="stat-chips">
+        <div class="chip" id="chiStat">χ²: —</div>
+        <div class="chip" id="iocStat">IOC: —</div>
+      </div>
+      <pre id="out"></pre>
+    </section>
+
+    <section class="panel hidden-control" id="wordlistPanel">
+      <h2>Wordlist Brute Force</h2>
+      <div class="small muted">Upload a wordlist and try all words at a selected position to find the best crib candidates.</div>
+      <div class="row" style="margin-top:10px">
+        <input type="file" id="wordlistFile" accept=".txt" />
+        <button id="selectMode">Select Word Position</button>
+        <label class="small muted">Max results:</label>
+        <input id="maxResults" type="number" min="1" value="20" style="width:72px" />
+              <label class="small muted">Quick trials:</label>
+        <input id="quickTrialsInput" type="number" min="0" value="30" style="width:72px" />
+        <label class="small muted">Trial depth:</label>
+        <input id="trialDepthInput" type="number" min="0" value="3" style="width:72px" />
+        <label class="small muted">Word timeout (ms):</label>
+        <input id="wordTimeoutInput" type="number" min="0" value="1500" style="width:90px" />
+        <label class="checkbox-row small" style="padding:0 6px 0 0">
+          <input type="checkbox" id="bruteBridgeNext" /> Enforce next crib
+        </label>
+        <button id="bruteForce">Brute force cribs</button>
+      </div>
+      <div id="wordlistStatus" class="small muted" style="margin-top:8px">No wordlist loaded</div>
+      <div id="selectionInfo" class="selection-info small">
+        <strong>Selection:</strong> <span id="selectionText">None</span> |
+        <strong>Position:</strong> <span id="selectionPos">-</span> |
+        <strong>Length:</strong> <span id="selectionLen">-</span>
+      </div>
+    </section>
+
+    <section class="panel hidden-control" id="bruteResults" style="display:none">
+      <h2>Brute Force Results</h2>
+      <div id="bruteSummary" class="small muted"></div>
+      <div id="bruteOut"></div>
+    </section>
   </div>
 
 <script>
@@ -185,6 +389,79 @@ function englishFitness(upArr){
   const subs = wordHits(s);
   const raw = chi + 4*subs;
   return (raw / n) * 100;
+}
+
+function computeEnglishStats(text){
+  const clean = sanitize(text || '');
+  const counts = {};
+  for (const ch of clean){ counts[ch] = (counts[ch] || 0) + 1; }
+  const n = clean.length;
+  let chi = 0;
+  let ic = 0;
+  if (n > 1){
+    for (const ch of A){
+      const obs = counts[ch] || 0;
+      const exp = FREQ[ch] * n / 100;
+      if (exp > 0){
+        const diff = obs - exp;
+        chi += (diff * diff) / exp;
+      }
+      ic += obs * (obs - 1);
+    }
+    ic /= (n * (n - 1));
+  } else if (n === 1){
+    ic = 0;
+  }
+  return { chi, ic, length: n, clean };
+}
+
+function scoreHeat(stats){
+  if (!stats || !stats.length){
+    return { score: 0, chi: stats ? stats.chi : 0, ic: stats ? stats.ic : 0, length: stats ? stats.length : 0 };
+  }
+  const CHI_TARGET = 33;
+  const CHI_SPREAD = 60;
+  const IOC_TARGET = 0.0667;
+  const IOC_SPREAD = 0.02;
+  const chiDelta = Math.abs((stats.chi || 0) - CHI_TARGET);
+  const chiScore = Math.max(0, 1 - (chiDelta / CHI_SPREAD));
+  const iocDelta = Math.abs((stats.ic || 0) - IOC_TARGET);
+  const iocScore = Math.max(0, 1 - (iocDelta / IOC_SPREAD));
+  const score = Math.max(0, Math.min(1, (chiScore * 0.6) + (iocScore * 0.4)));
+  return { score, chi: stats.chi, ic: stats.ic, length: stats.length };
+}
+
+function updateHeatMeter(stats){
+  const heatFill = document.getElementById('heatFill');
+  const chiStat = document.getElementById('chiStat');
+  const iocStat = document.getElementById('iocStat');
+  if (!heatFill || !chiStat || !iocStat){
+    return { score: 0, chi: 0, ic: 0 };
+  }
+  if (!stats || !stats.length){
+    heatFill.style.width = '0%';
+    heatFill.style.opacity = '0.35';
+    chiStat.textContent = 'χ²: —';
+    iocStat.textContent = 'IOC: —';
+    return { score: 0, chi: 0, ic: 0 };
+  }
+  const scored = scoreHeat(stats);
+  const pct = Math.round(scored.score * 100);
+  heatFill.style.width = `${pct}%`;
+  heatFill.style.opacity = '1';
+  const chiVal = scored.chi.toFixed(2);
+  const iocVal = scored.ic.toFixed(4);
+  chiStat.textContent = `χ²: ${chiVal}`;
+  iocStat.textContent = `IOC: ${iocVal}`;
+  return scored;
+}
+
+function resetHeatMeter(){
+  updateHeatMeter(null);
+  const summary = document.getElementById('summary');
+  if (summary){
+    summary.textContent = 'No test run yet — add a few guesses to start!';
+  }
 }
 
 const AUTOKEY_ALGOS = ['vigenere','beaufort','beaufort_variant'];
@@ -1915,6 +2192,29 @@ try{
     const BRUTE_SUMMARY = $("bruteSummary");
     const BRUTE_OUT = $("bruteOut");
 
+    const DEFAULT_MIN_K = 4;
+    const DEFAULT_MAX_K = 20;
+
+    if (SEL_OP){
+      SEL_OP.value = 'autokey_custom_alpha';
+      SEL_OP.disabled = true;
+    }
+    const MIN_K_INPUT = $("minK");
+    const MAX_K_INPUT = $("maxK");
+    if (MIN_K_INPUT){
+      MIN_K_INPUT.value = DEFAULT_MIN_K;
+      MIN_K_INPUT.disabled = true;
+    }
+    if (MAX_K_INPUT){
+      MAX_K_INPUT.value = DEFAULT_MAX_K;
+      MAX_K_INPUT.disabled = true;
+    }
+    if (SEL_AUTOKEY_ALGO){
+      SEL_AUTOKEY_ALGO.value = normalizeAutokeyAlgo(SEL_AUTOKEY_ALGO.value);
+    }
+    updateAutokeyAlgoVisibility();
+    resetHeatMeter();
+
     let uaWorker = null;
     let currentJob = null;
     let bruteCtx = null;
@@ -1943,8 +2243,10 @@ try{
         if (!letter) return;
         cribPairs.push([pos, letter]);
       });
-      const minK = $("minK") ? parseInt($("minK").value) : 2;
-      const maxK = $("maxK") ? parseInt($("maxK").value) : 20;
+      if (MIN_K_INPUT) MIN_K_INPUT.value = DEFAULT_MIN_K;
+      if (MAX_K_INPUT) MAX_K_INPUT.value = DEFAULT_MAX_K;
+      const minK = DEFAULT_MIN_K;
+      const maxK = DEFAULT_MAX_K;
       const op = SEL_OP ? SEL_OP.value : '';
       return { letters, cribPairs, minK, maxK, op, autokeyAlgo: currentAutokeyAlgo() };
     }
@@ -3055,7 +3357,6 @@ try{
 
     function resetStop(){
       if (BTN_STOP){
-        BTN_STOP.style.display = 'none';
         BTN_STOP.disabled = true;
       }
     }
@@ -3063,14 +3364,8 @@ try{
     function updateStopVisibility(){
       updateAutokeyAlgoVisibility();
       if (!BTN_STOP) return;
-      if (currentJob){
-        BTN_STOP.style.display = 'inline-block';
-        BTN_STOP.disabled = false;
-        return;
-      }
-      const show = !!(SEL_OP && (SEL_OP.value === 'vig_custom_alpha' || SEL_OP.value === 'autokey_custom_alpha'));
-      BTN_STOP.style.display = show ? 'inline-block' : 'none';
-      BTN_STOP.disabled = !show;
+      BTN_STOP.style.display = 'inline-block';
+      BTN_STOP.disabled = !currentJob;
     }
 
     function stopWorker(summaryText, outText){
@@ -3090,6 +3385,7 @@ try{
         if (typeof summaryText === 'string' && SUMMARY) SUMMARY.textContent = summaryText;
         if (typeof outText === 'string' && OUT) OUT.textContent = outText;
       }
+      updateHeatMeter(null);
       currentJob = null;
       bruteCtx = null;
       resetStop();
@@ -3112,7 +3408,6 @@ try{
 
       if (BTN_TEST) BTN_TEST.disabled = true;
       if (BTN_STOP){
-        BTN_STOP.style.display = 'inline-block';
         BTN_STOP.disabled = false;
       }
       updateStopVisibility();
@@ -3169,12 +3464,13 @@ try{
         if (kind === 'result' || kind === 'done'){
           hideProgress();
           if (BTN_STOP){
-            BTN_STOP.style.display = 'none';
             BTN_STOP.disabled = true;
           }
           if (BTN_TEST) BTN_TEST.disabled = false;
           try { uaWorker.terminate(); } catch(e){}
           uaWorker = null;
+          currentJob = null;
+          updateStopVisibility();
 
           const baseResults = Array.isArray(data.results) && data.results.length ? data.results : streamed;
           if (!baseResults.length){
@@ -3207,41 +3503,25 @@ try{
             return;
           }
           baseResults.sort((a,b)=> (b.score||0) - (a.score||0));
-          if (SUMMARY) SUMMARY.textContent = `Found ${baseResults.length} solution(s) for ${modeLabel}.`;
-          if (OUT) OUT.textContent = '';
-          const target = OUT || document.createElement('div');
           const best = baseResults[0];
-          if (best && best.posRaw && best.kRaw){
-            const alphaInfo = alphabetInfoFromPositions(best.posRaw);
-            const alphaStr = alphaInfo.invString;
-            const block = document.createElement('pre');
-            const variantLine = isAutokey ? `variant:    ${autokeyAlgoLabel(payload.autokeyAlgo)}\n` : '';
-            const displayKey = isAutokey
-              ? (best.actualKey || best.kRaw.map(v => alphaInfo.inv[v] || '?').join(''))
-              : best.key;
-            const residuesLine = isAutokey ? `key residues: ${best.key}\n` : '';
-            block.textContent =
-              `Best candidate (m=${best.keyLength})\n` +
-              `${isAutokey ? 'initial key: ' : 'key residues: '}${displayKey}\n` +
-              residuesLine +
-              variantLine +
-              `alphabet:    ${alphaStr}\n\n` +
-              (best.full || '');
-            target.appendChild(block);
+          if (!best){
+            if (SUMMARY) SUMMARY.textContent = 'We searched the range but did not land on a readable decrypt.';
+            if (OUT) OUT.textContent = '';
+            updateHeatMeter(null);
+            return;
           }
-          baseResults.slice(0,50).forEach((r, idx)=>{
-            const row = document.createElement('div'); row.className = 'row';
-            const keyDisplay = isAutokey ? (r.actualKey || r.key) : r.key;
-            const residuesInfo = (isAutokey && r.actualKey && r.actualKey !== r.key) ? ` (residues ${r.key})` : '';
-            const head = document.createElement('div'); head.textContent = `#${idx+1}  m=${r.keyLength}  initialKey=${keyDisplay}${residuesInfo}`;
-            const body = document.createElement('div'); body.className = 'small muted'; body.textContent = r.preview || '';
-            row.appendChild(head);
-            row.appendChild(body);
-            target.appendChild(row);
-          });
-          if (!OUT){
-            const container = $("out");
-            if (container) container.appendChild(target);
+          if (OUT){
+            OUT.textContent = best.full || '';
+          }
+          const stats = computeEnglishStats(best.full || '');
+          const scored = updateHeatMeter(stats);
+          if (SUMMARY){
+            const pct = Math.round((scored.score || 0) * 100);
+            let mood = 'Chilly — try adding more crib letters to warm it up.';
+            if (pct >= 75) mood = 'Hot! This looks a lot like natural English.';
+            else if (pct >= 45) mood = 'Warm — you are closing in on a readable solution.';
+            else if (pct === 0) mood = 'We need more clues before the heat meter can move.';
+            SUMMARY.textContent = `Key length ${best.keyLength}: ${mood}`;
           }
         }
       };
@@ -3287,9 +3567,9 @@ try{
 
       if (BTN_BRUTE) BTN_BRUTE.disabled = true;
       if (BTN_STOP){
-        BTN_STOP.style.display = 'inline-block';
         BTN_STOP.disabled = false;
       }
+      updateStopVisibility();
       if (BRUTE_PANEL) BRUTE_PANEL.style.display = 'block';
       if (BRUTE_OUT) BRUTE_OUT.innerHTML = '';
       if (BRUTE_SUMMARY){
@@ -3343,7 +3623,6 @@ try{
         if (kind === 'brute_done'){
           hideProgress();
           if (BTN_STOP){
-            BTN_STOP.style.display = 'none';
             BTN_STOP.disabled = true;
           }
           if (BTN_BRUTE) BTN_BRUTE.disabled = false;

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       line-height: 1.5;
     }
     .panels {
-      width: min(1280px, 100%);
+      width: min(1400px, 100%);
       margin: 0 auto;
       display: flex;
       flex-direction: column;
@@ -91,13 +91,30 @@
     }
     .grid {
       display:flex;
-      gap:8px;
+      gap:14px 12px;
       flex-wrap:wrap;
       margin-top:16px;
       padding:18px;
       border-radius:16px;
       background:linear-gradient(145deg, rgba(56,189,248,0.08), rgba(15,118,110,0.08));
       border:1px solid rgba(148,163,184,0.12);
+      align-items:flex-start;
+    }
+    .word {
+      display:flex;
+      flex-wrap:nowrap;
+      flex:0 0 auto;
+      gap:8px;
+    }
+    .word-gap {
+      flex:0 0 26px;
+      height:1px;
+      pointer-events:none;
+    }
+    .line-break {
+      flex-basis:100%;
+      height:0;
+      pointer-events:none;
     }
     .cell {
       width:38px;
@@ -263,15 +280,22 @@
 
     @media (min-width: 1100px) {
       body { padding:48px 48px 72px; }
-      .hero { width:min(1040px, 100%); }
+      .hero { width:min(1100px, 100%); }
       .panels {
         display:grid;
         grid-template-columns:repeat(12, minmax(0, 1fr));
         gap:22px;
+        grid-template-areas:
+          "setup setup setup setup results results results results results results results results"
+          "grid grid grid grid grid grid grid grid grid grid grid grid"
+          "wordlist wordlist wordlist wordlist wordlist wordlist wordlist wordlist wordlist wordlist wordlist wordlist"
+          "brute brute brute brute brute brute brute brute brute brute brute brute";
       }
-      #setupPanel, #gridPanel { grid-column:span 6; }
-      #results { grid-column:span 12; }
-      .panel.hidden-control { grid-column:span 12; }
+      #setupPanel { grid-area: setup; }
+      #results { grid-area: results; }
+      #gridPanel { grid-area: grid; }
+      #wordlistPanel { grid-area: wordlist; }
+      #bruteResults { grid-area: brute; }
     }
   </style>
 </head>
@@ -663,10 +687,56 @@ function renderGrid(){
   const letters = raw.split('');
   const grid = document.getElementById('grid');
   grid.innerHTML = '';
-  
+
   let letterIndex = 0;
-  
+  let wordWrap = null;
+
+  const flushWord = () => {
+    if (wordWrap && wordWrap.childNodes.length){
+      grid.appendChild(wordWrap);
+    }
+    wordWrap = null;
+  };
+
+  const focusStep = (start, direction) => {
+    let pointer = start + direction;
+    while (pointer >= 0 && pointer < letters.length){
+      const target = grid.querySelector(`input.cribin[data-pos="${pointer}"]`);
+      if (target && !target.disabled){
+        target.focus();
+        return target;
+      }
+      pointer += direction;
+    }
+    return null;
+  };
+
   letters.forEach((ch, idx) => {
+    if (ch === '\r'){
+      return;
+    }
+
+    if (ch === '\n'){
+      flushWord();
+      const breaker = document.createElement('div');
+      breaker.className = 'line-break';
+      grid.appendChild(breaker);
+      return;
+    }
+
+    if (ch === ' '){
+      flushWord();
+      const spacer = document.createElement('div');
+      spacer.className = 'word-gap';
+      grid.appendChild(spacer);
+      return;
+    }
+
+    if (!wordWrap){
+      wordWrap = document.createElement('div');
+      wordWrap.className = 'word';
+    }
+
     const cell = document.createElement('div');
     cell.className = 'cell';
     cell.dataset.absIdx = idx;
@@ -688,7 +758,7 @@ function renderGrid(){
     } else {
       cell.dataset.letterIdx = letterIndex;
       letterIndex++;
-      
+
       // Selection mode click handler
       cell.addEventListener('click', (e) => {
         if (selectionMode){
@@ -708,40 +778,34 @@ function renderGrid(){
           crib.focus();
         }
       });
-      
+
       crib.addEventListener('input', () => {
         crib.value = sanitize(crib.value);
         if (crib.value.length === 1){
-          let next = crib.parentElement.nextElementSibling;
-          while (next && (!next.querySelector('input.cribin') || next.querySelector('input.cribin').disabled)) next = next.nextElementSibling;
-          if (next) next.querySelector('input.cribin').focus();
+          focusStep(idx, 1);
         }
       });
       crib.addEventListener('keydown', (e) => {
         if ((e.key === 'Backspace' || e.key==='Delete') && !crib.value){
-          let prev = crib.parentElement.previousElementSibling;
-          while (prev && (!prev.querySelector('input.cribin') || prev.querySelector('input.cribin').disabled)) prev = prev.previousElementSibling;
-          if (prev) prev.querySelector('input.cribin').focus();
+          focusStep(idx, -1);
         } else if (e.key === 'ArrowRight'){
-          let next = crib.parentElement.nextElementSibling;
-          while (next && (!next.querySelector('input.cribin') || next.querySelector('input.cribin').disabled)) next = next.nextElementSibling;
-          if (next) next.querySelector('input.cribin').focus();
+          focusStep(idx, 1);
         } else if (e.key === 'ArrowLeft'){
-          let prev = crib.parentElement.previousElementSibling;
-          while (prev && (!prev.querySelector('input.cribin') || prev.querySelector('input.cribin').disabled)) prev = prev.previousElementSibling;
-          if (prev) prev.querySelector('input.cribin').focus();
+          focusStep(idx, -1);
         }
       });
     }
 
     cell.appendChild(cspan);
     cell.appendChild(crib);
-    grid.appendChild(cell);
+    wordWrap.appendChild(cell);
   });
+
+  flushWord();
+
   const first = grid.querySelector('input.cribin:not([disabled])');
   if (first) first.focus();
 }
-
 // ===== Data extraction =====
 function gatherCribs(){
   const raw = document.getElementById('ctext').value;


### PR DESCRIPTION
## Summary
- restyle the page into a guided puzzle playground aimed at autokey users
- lock the solver to the autokey unknown alphabet mode with a fixed 4-20 key range and hide advanced controls
- add a hot/cold heat meter that scores decrypts with IOC and chi-squared while simplifying the results view

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e70f418cf483319406c93d840f1a9e